### PR TITLE
E7X post-launch update, Norwegian sections sync, frontpage carousel refresh

### DIFF
--- a/content/models/e7x/_index .nb.md
+++ b/content/models/e7x/_index .nb.md
@@ -1,25 +1,30 @@
 ---
 title: AUDI E7X
 linktitle: AUDI E7X
-description: AUDI E7X er en Kina-eksklusiv, helelektrisk premium-SUV utviklet sammen med SAIC, med planlagt debut på Auto China 2026.
+description: AUDI E7X er en Kina-eksklusiv, helelektrisk premium-SUV utviklet med SAIC, avduket på Auto China 2026 i Beijing og lansert i første halvdel av 2026.
 weight: 10
 shownavtabs: true
 ---
 <!-- markdownlint-disable MD033 -->
 
-**AUDI E7X** er en **Kina-eksklusiv, helelektrisk premium-SUV** og den **andre produksjonsmodellen** fra **AUDI**, søstermerket kun for Kina som er etablert gjennom samarbeidet mellom AUDI og SAIC. Etter AUDI E5 Sportback utvider E7X Audis lokaltilpassede elektriske portefølje, utviklet spesielt for kinesiske kunder.
+**AUDI E7X** er en **Kina-eksklusiv, helelektrisk premium-SUV** og den **andre produksjonsmodellen** fra **AUDI**, søstermerket kun for Kina som er etablert gjennom samarbeidet mellom AUDI og SAIC. Den følger etter AUDI E5 Sportback — kåret til **Kinas Årets Bil 2026** — og viderefører Audis strategi med å utvikle lokaltilpassede elbiler spesielt for det kinesiske markedet.
 
-{{< sitefiguresized thumb="models/e7x/exterior/exterior_1_st.webp" width="3000" height="2250" title="Audi E5 Sportback" >}}
+{{< sitefiguresized thumb="models/e7x/exterior/exterior_1_st.webp" width="3000" height="2250" title="AUDI E7X" >}}
 
-Modellen får sin **offisielle verdenspremiere på Auto China 2026 i Beijing**, som arrangeres fra 24. april til 3. mai 2026, med **markedsintroduksjon planlagt i første halvdel av 2026**.
+AUDI E7X hadde sin **verdenspremiere på Auto China 2026 i Beijing den 24. april 2026**, og ble lansert i **første halvdel av 2026**. Produksjonen foregår ved **AUDIs intelligente produksjonsbase i Anting, Shanghai**.
 
 ---
 
 ## Posisjonering og konsept
 
-AUDI E7X er posisjonert som en **stor, helelektrisk premium-SUV**, utviklet uten kompromisser mellom daglig bruk, ytelse og emosjonell appell. Ifølge Audi er modellen rettet direkte mot **teknologibevisste kinesiske kunder**, og kombinerer Audis kjøredynamikk og byggekvalitet med dyp integrasjon i Kinas digitale økosystem.
+AUDI E7X er posisjonert som en **stor, helelektrisk premium-SUV**, utviklet uten kompromisser mellom daglig bruk, ytelse og emosjonell appell. Modellen er rettet mot **teknologibevisste kinesiske kunder**, og kombinerer Audis kjøredynamikk og byggekvalitet med dyp integrasjon i Kinas digitale økosystem.
 
-I motsetning til globale Audi-modeller benytter ikke AUDI-modellene **de klassiske fire ringene**, men har i stedet merkenavnet skrevet med store bokstaver – et tydelig uttrykk for deres egen identitet i det kinesiske markedet.
+I motsetning til globale Audi-modeller benytter ikke AUDI-modellene **de klassiske fire ringene**, men har i stedet merkenavnet skrevet med store bokstaver – et tydelig uttrykk for deres unike identitet i det kinesiske markedet.
+
+E7X er del av en **plan med tre modeller** for AUDI-merket i Kina:
+1. **AUDI E5 Sportback** — lansert september 2025, Kinas Årets Bil 2026
+2. **AUDI E7X** — lansert H1 2026
+3. **Helelektrisk sedan** — verdenspremiere 2027
 
 ---
 
@@ -29,47 +34,79 @@ Eksteriørdesignet til AUDI E7X følger tett **AUDI E SUV-konseptet**, og overf�
 
 Viktige designtrekk inkluderer:
 
-- Rene, monolittiske flater med et rolig, men markant uttrykk  
-- Oppreist front med sort, omsluttende designelement  
-- Vertikalt arrangerte **digitale Matrix LED-frontlykter**  
-- Korte overheng og kraftig modellerte hjulbuer  
+- **AUDI Light Frame** — en omsluttende frontlysarkitektur med over **1 000 individuelt styrbare trekantede LED-elementer**
+- Vertikalt arrangerte **digitale Matrix LED-frontlykter** med fil- og posisjonsmarkering
+- Sort, omsluttende designelement som integrerer lykter og sensorer
+- **Dørløse rammer (frameless doors)** for et rent, eksklusivt uttrykk
+- Korte overheng og kraftig modellerte hjulbuer
+- Muskuløs skulderpartilinje og bred SUV-stans
 
-Proporsjonene understreker bilens status som premium-SUV:
+Bekreftede dimensjoner:
 
-- Lengde: **5 049 mm**  
-- Bredde: **2 002 mm**  
-- Høyde: **1 708 mm**  
+- Lengde: **5 049 mm**
+- Bredde: **1 997 mm** (uten speil)
+- Høyde: **1 710 mm**
 - Akselavstand: **3 060 mm**
+- Svingradius: **10,3 m**
 
-Disse målene gir E7X en kombinasjon av **romslig kupé** og en selvsikker, representativ tilstedeværelse på veien.
+{{< sitefiguresized thumb="models/e7x/exterior/exterior_2_st.webp" width="3000" height="2250" title="AUDI E7X" >}}
 
-{{< sitefiguresized thumb="models/e7x/exterior/exterior_2_st.webp" width="3000" height="2250" title="Audi E5 Sportback" >}}
+---
+
+## Interiør
+
+E7X-kabinen tilbys i to seteoppsettkonfigurasjoner:
+
+- **Femseters familieversjon** — full bredde baksetebenk
+- **Firseters executive-versjon** — individuelle bakseter med premiumfunksjoner i første klasse-stil
+
+Sentrum for dashbordet er et **27-tommers 4K panoramadisplay** som strekker seg over hele bredden av instrument- og infotainmentområdet. Et **21,4-tommers bakre takdisplay** foldes ned fra taket for baksetespassasjerer.
+
+Stemme- og AI-grensesnittet håndteres av **AUDI Assistant 2.0**, co-utviklet med **ByteDance**, med dyp integrasjon i kinesiske digitale tjenester og betydelig forbedret konversasjons-AI.
+
+De bakre executive-setene i firsetersversjonen tilbyr:
+
+- **120° full tilbakelening** til nesten flat posisjon
+- **23-punkts pneumatisk justeringssystem** med luftputebasert støtteforming
+- **16-punkts massasjefunksjon**
+- Elektrisk fotavstøtter med opptil **400 mm rekkevidde**
 
 ---
 
 ## Plattform og drivlinje
 
-AUDI E7X er bygget på **Advanced Digitized Platform**, utviklet i samarbeid med SAIC. Plattformen danner grunnlaget for en ny generasjon **intelligente og tilkoblede elbiler** for det kinesiske markedet, og muliggjør betydelig kortere utviklingstider gjennom tett samarbeid mellom Audis team i Tyskland og Kina.
+AUDI E7X er bygget på **Advanced Digitized Platform (ADP)**, utviklet i samarbeid med SAIC. Plattformen har sonebasert elektronikkarkitektur og støtter heldekkende **OTA-oppdateringer** av kjøretøyet.
 
-To drivlinjevarianter vil være tilgjengelige:
+To batterikapasiteter er tilgjengelige:
 
-- **300 kW** systemeffekt  
-- **500 kW** systemeffekt  
+- **100 kWh** — opptil 750+ km CLTC rekkevidde
+- **109 kWh** — maksimal rekkeviddeversjon
 
-Begge konfigurasjonene er utviklet for å levere **sterk ytelse og typisk Audi-kjøredynamikk**, og plasserer E7X solid i det øvre premiumsegmentet for elbiler.
+Plattformen benytter **900-volts elektrisk arkitektur**, som muliggjør **4C-hurtiglading**: fra 10 % til 80 % på kun **13 minutter**.
+
+To drivlinjevarianter tilbys:
+
+- **300 kW** enkeltmotor bakhjulsdrift
+- **500 kW** tomotors quattro firehjulsdrift (0–100 km/t på 3,9 sekunder)
+
+**Firehjulsstyring** er standard på hele modellprogrammet, noe som reduserer svingradiusen til **10,3 meter** til tross for E7Xs store dimensjoner.
+
+---
+
+## Teknologi
+
+Kjøreassistansen håndteres av **AUDI 360 Driving Assist**, co-utviklet med **Momenta** og utstyrt med **lidar-sensor** for forbedret omgivelsespersepsjon. Systemet dekker:
+
+- Langsgående og tverrgående kjøreassistanse på motorvei og i by
+- Minneparkering for parkeringshus og parkeringsplasser
+- Dynamiske veiinformasjonsprosjeksjoner
+
+**Bose Performance Series**-lydsystemet leverer **26 høyttalere** med 360° romlig lyd.
 
 ---
 
 ## Rollen i Audis Kina-strategi
 
-Med E7X viderefører AUDI strategien om å tilby **regionsspesifikke elbiler** som kompletterer den globale Audi-porteføljen i Kina, snarere enn å erstatte den. E7X kombinerer:
+Med E7X viderefører AUDI strategien om å tilby **regionsspesifikke elbiler** som kompletterer den globale Audi-porteføljen i Kina. E7X kombinerer Audi-DNA i kjøredynamikk og kvalitet, sømløs integrasjon i Kinas digitale økosystem og et dristig, progressivt SUV-design — alt produsert lokalt i Shanghai.
 
-- Audi-DNA når det gjelder kjøredynamikk og kvalitet  
-- Sømløs integrasjon i Kinas digitale og tilkoblede økosystem  
-- Et dristig og progressivt SUV-design  
-
-Sammen med AUDI E5 Sportback understreker E7X Audis satsing på **lokal innovasjon** i sitt viktigste elbilmarked.
-
-Flere detaljer om interiør, programvare og førerassistansesystemer forventes nærmere den offisielle premieren på Auto China 2026.
-
-{{< gallery images="models/e7x/exterior/exterior_1_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_2_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_3_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_4_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_5_st.webp|Audi E7X|3000|1688" >}}
+{{< gallery images="models/e7x/exterior/exterior_1_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_2_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_3_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_4_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_5_st.webp|AUDI E7X|3000|1688" >}}

--- a/content/models/e7x/_index.md
+++ b/content/models/e7x/_index.md
@@ -1,25 +1,30 @@
 ---
 title: AUDI E7X
 linktitle: AUDI E7X
-description: The AUDI E7X is a China-exclusive, fully electric premium SUV developed with SAIC and set to debut at Auto China 2026.
+description: The AUDI E7X is a China-exclusive, fully electric premium SUV developed with SAIC, unveiled at Auto China 2026 in Beijing and launched in the first half of 2026.
 weight: 10
 shownavtabs: true
 ---
 <!-- markdownlint-disable MD033 -->
 
-The **AUDI E7X** is a **China-exclusive, fully electric premium SUV** and the **second production model** from **AUDI**, the China-only sister brand created through the cooperation between AUDI and SAIC. Following the AUDI E5 Sportback, the E7X further expands Audi’s localized electric portfolio tailored specifically to Chinese customers.
+The **AUDI E7X** is a **China-exclusive, fully electric premium SUV** and the **second production model** from **AUDI**, the China-only sister brand created through the cooperation between AUDI and SAIC. It follows the AUDI E5 Sportback — named **China Car of the Year 2026** — and continues Audi's strategy of developing localized electric vehicles specifically for the Chinese market.
 
-{{< sitefiguresized thumb="models/e7x/exterior/exterior_1_st.webp" width="3000" height="2250" title="Audi E5 Sportback" >}}
+{{< sitefiguresized thumb="models/e7x/exterior/exterior_1_st.webp" width="3000" height="2250" title="AUDI E7X" >}}
 
-The model will make its **public debut at Auto China 2026 in Beijing**, taking place from April 24 to May 3, 2026, with a **market launch planned for the first half of 2026**.
+The AUDI E7X made its **world premiere at Auto China 2026 in Beijing on April 24, 2026**, and entered the market in the **first half of 2026**. Production takes place at the **AUDI intelligent production base in Anting, Shanghai**.
 
 ---
 
 ## Positioning and concept
 
-The AUDI E7X is positioned as a **large, fully electric premium SUV**, designed without compromise between everyday usability, performance, and emotional appeal. According to Audi, it is aimed squarely at **tech-savvy Chinese customers**, combining Audi’s driving dynamics and build quality with deep integration into China’s digital ecosystem.
+The AUDI E7X is positioned as a **large, fully electric premium SUV**, designed without compromise between everyday usability, performance, and emotional appeal. It is aimed squarely at **tech-savvy Chinese customers**, combining Audi driving dynamics and build quality with deep integration into China's digital ecosystem.
 
 Unlike global Audi models, AUDI-branded vehicles **do not wear the four-ring logo**, instead featuring the brand name written in capital letters, underlining their distinct identity within the Chinese market.
+
+The E7X is part of a **three-model roadmap** for the AUDI brand in China:
+1. **AUDI E5 Sportback** — launched September 2025, China Car of the Year 2026
+2. **AUDI E7X** — launched H1 2026
+3. **All-electric sedan** — world premiere 2027
 
 ---
 
@@ -29,49 +34,79 @@ The exterior design of the AUDI E7X closely follows the **AUDI E SUV concept**, 
 
 Key design characteristics include:
 
-- Clean, monolithic surfaces with a calm yet striking appearance  
-- Upright front end with a black wraparound loop  
-- Vertically arranged **digital Matrix LED headlights**  
-- Short overhangs and powerfully sculpted wheel arches  
+- **AUDI Light Frame** — a wraparound front light architecture with over **1,000 individually controllable triangular LED elements**
+- Vertically arranged **digital Matrix LED headlights** with lane and position marking
+- Black wraparound loop integrating lights and sensors
+- **Frameless doors** for a clean, premium appearance
+- Short overhangs and powerfully sculpted wheel arches
+- Muscular shoulder line and wide SUV stance
 
-The proportions underline its premium SUV status:
+Confirmed dimensions:
 
-- Length: **5,049 mm**  
-- Width: **2,002 mm**  
-- Height: **1,708 mm**  
+- Length: **5,049 mm**
+- Width: **1,997 mm** (excluding mirrors)
+- Height: **1,710 mm**
 - Wheelbase: **3,060 mm**
+- Turning circle: **10.3 m**
 
-These dimensions allow the E7X to combine a **spacious interior** with a confident and prestigious road presence.
+{{< sitefiguresized thumb="models/e7x/exterior/exterior_2_st.webp" width="3000" height="2250" title="AUDI E7X" >}}
 
-{{< sitefiguresized thumb="models/e7x/exterior/exterior_2_st.webp" width="3000" height="2250" title="Audi E5 Sportback" >}}
+---
 
+## Interior
+
+The E7X cabin is available in two seating configurations:
+
+- **Five-seat family version** — full-width rear bench
+- **Four-seat executive version** — individual rear seats with premium first-class features
+
+The centerpiece of the dashboard is a **27-inch 4K panoramic display** stretching across the full width of the instrument and infotainment areas. A **21.4-inch rear ceiling display** deploys from the headliner for rear occupants.
+
+The voice and AI interface is handled by **AUDI Assistant 2.0**, co-developed with **ByteDance**, delivering deep integration with Chinese digital services and significantly enhanced conversational AI capability.
+
+The executive rear seats in the four-seat version offer:
+
+- **120° full recline** to a near-flat position
+- **23-point pneumatic adjustment system** with airbag-based support shaping
+- **16-point massage function**
+- Electric extendable footrest with up to **400 mm of travel**
 
 ---
 
 ## Platform and drivetrain
 
-The AUDI E7X is built on the **Advanced Digitized Platform**, jointly developed with SAIC. This platform underpins a new generation of **intelligent, connected electric vehicles** for the Chinese market and enables significantly reduced development times through close collaboration between Audi’s teams in Germany and China.
+The AUDI E7X is built on the **Advanced Digitized Platform (ADP)**, jointly developed with SAIC. This platform features zonal electronic architecture and supports full-vehicle **over-the-air (OTA) updates**.
 
-Two powertrain variants will be available:
+Two battery options are available:
 
-- **300 kW** system output  
-- **500 kW** system output  
+- **100 kWh** — supporting up to 750+ km CLTC range
+- **109 kWh** — maximum range configuration
 
-Both configurations are designed to deliver **strong performance and Audi-typical driving dynamics**, positioning the E7X firmly in the upper premium EV segment.
+The platform runs a **900-volt electrical architecture**, enabling **4C fast charging**: from 10% to 80% in just **13 minutes**.
+
+Two powertrain configurations are offered:
+
+- **300 kW** single-motor rear-wheel drive
+- **500 kW** dual-motor quattro all-wheel drive (0–100 km/h in 3.9 seconds)
+
+**All-wheel steering** is standard across the entire range, reducing the turning circle to **10.3 metres** despite the E7X's large footprint.
 
 ---
 
-## Role within Audi’s China strategy
+## Technology
 
-With the E7X, AUDI continues its strategy of offering **region-specific electric models** that complement the global Audi lineup in China rather than replacing it. The E7X combines:
+Driver assistance is handled by the **AUDI 360 Driving Assist** system, co-developed with **Momenta** and featuring a **lidar sensor** for enhanced environmental perception. The system covers:
 
-- Audi DNA in terms of dynamics and quality  
-- Seamless integration into China’s digital and connectivity ecosystem  
-- A bold, progressive SUV design  
+- Highway and urban longitudinal and lateral control
+- Memory parking for garages and parking lots
+- Dynamic road-projected warning indicators
 
-Together with the AUDI E5 Sportback, the E7X highlights Audi’s commitment to **localized innovation** in its most important electric vehicle market.
+The **Bose Performance Series** sound system delivers **26 speakers** with 360° spatial audio.
 
-More details on the interior, software, and driving assistance systems are expected closer to the official debut at Auto China 2026.
+---
 
+## Role within Audi's China strategy
 
-{{< gallery images="models/e7x/exterior/exterior_1_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_2_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_3_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_4_st.webp|Audi E7X|3000|2000,models/e7x/exterior/exterior_5_st.webp|Audi E7X|3000|1688" >}}
+With the E7X, AUDI continues its strategy of offering **region-specific electric models** that complement the global Audi lineup in China. The E7X combines Audi DNA in dynamics and quality, seamless integration into China's digital ecosystem, and a bold, progressive SUV design — all produced locally in Shanghai.
+
+{{< gallery images="models/e7x/exterior/exterior_1_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_2_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_3_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_4_st.webp|AUDI E7X|3000|2000,models/e7x/exterior/exterior_5_st.webp|AUDI E7X|3000|1688" >}}

--- a/content/models/e7x/drivetrain/_index.md
+++ b/content/models/e7x/drivetrain/_index.md
@@ -25,7 +25,12 @@ The dual-motor variants sprint from 0–100 km/h in just 3.9 seconds, while the 
 
 ## Battery & charging
 
-All variants are equipped with a **100 kWh (gross) NMC battery**. The E7X supports up to **400 kW DC fast charging**, enabling very short charging stops. The charge port is located on the right rear side of the vehicle.
+Two battery options are available across the E7X range:
+
+- **100 kWh** — supporting CLTC range from 635 km (quattro) to 751 km (Pioneer Long-Range)
+- **109 kWh** — maximum range configuration
+
+The E7X uses a **900-volt electrical architecture** and supports **4C fast charging**, enabling a charge from **10% to 80% in just 13 minutes**. The charge port is located on the right rear side of the vehicle.
 
 CLTC-rated range varies by variant:
 
@@ -34,6 +39,12 @@ CLTC-rated range varies by variant:
 - Pioneer Long-Range: 751 km
 - Pioneer quattro: 635 km
 - Flagship quattro: 660 km
+
+## Steering
+
+The AUDI E7X features **all-wheel steering** as standard across the entire range — both front and rear wheels steer, reducing the turning circle to **10.3 metres** despite the E7X's 5,049 mm length. Progressive steering ratio adjusts automatically with speed for precise low-speed manoeuvrability and stability at highway speeds.
+
+**AUDI drive select** offers multiple driving modes including a dedicated **off-road mode** with settings optimised for low-traction surfaces.
 
 ## Suspension
 

--- a/content/models/e7x/drivetrain/_index.md
+++ b/content/models/e7x/drivetrain/_index.md
@@ -47,10 +47,10 @@ The AUDI E7X uses an adaptive suspension setup across all variants, with the lev
 
 From the **Pioneer Pro** upwards, the **Audi Track-level Chassis** package adds **CDC continuous damping control combined with air suspension**, replacing the standard adaptive damper setup. The all-aluminum chassis construction further reduces unsprung mass. This package is included as a limited-time gift on the Pioneer Pro, Pioneer quattro and above.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/chassis_4e086_st.webp" width="3000" height="2000" title="AUDI E7X chassis" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/chassis_4e086_st.webp" width="1920" height="1080" title="AUDI E7X chassis" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/chassis_d2e7e_st.webp" width="3000" height="2000" title="AUDI E7X chassis" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/chassis_d2e7e_st.webp" width="1920" height="1080" title="AUDI E7X chassis" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/batterypack_94a4c_st.webp" width="3000" height="2000" title="AUDI E7X battery pack" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/batterypack_94a4c_st.webp" width="1920" height="1080" title="AUDI E7X battery pack" >}}
 
 {{<children description="true" />}}

--- a/content/models/e7x/drivetrain/_index.nb.md
+++ b/content/models/e7x/drivetrain/_index.nb.md
@@ -25,7 +25,12 @@ Firehjulsdriftsvariantene akselererer fra 0–100 km/t på kun 3,9 sekunder, men
 
 ## Batteri og lading
 
-Alle varianter er utstyrt med et **100 kWh (brutto) NMC-batteri**. E7X støtter opptil **400 kW DC hurtiglading**, noe som muliggjør svært korte ladestop. Ladeporten er plassert på høyre bakre side av bilen.
+To batterikapasiteter er tilgjengelige i E7X-programmet:
+
+- **100 kWh** — støtter CLTC-rekkevidde fra 635 km (quattro) til 751 km (Pioneer Long-Range)
+- **109 kWh** — maksimal rekkeviddekonfigurasjon
+
+E7X benytter **900-volts elektrisk arkitektur** og støtter **4C-hurtiglading**, noe som muliggjør lading fra **10 % til 80 % på bare 13 minutter**. Ladeporten er plassert på høyre bakre side av bilen.
 
 CLTC-rekkevidde varierer etter variant:
 
@@ -34,6 +39,12 @@ CLTC-rekkevidde varierer etter variant:
 - Pioneer Long-Range: 751 km
 - Pioneer quattro: 635 km
 - Flagship quattro: 660 km
+
+## Styring
+
+AUDI E7X har **firehjulsstyring** som standard på hele modellprogrammet — både for- og bakhjul styres, noe som reduserer svingradiusen til **10,3 meter** til tross for E7Xs lengde på 5 049 mm. Progressivt styringsforhold justeres automatisk med hastigheten for presis manøvrerbarhet i lav hastighet og stabilitet i motorveifart.
+
+**AUDI drive select** tilbyr flere kjøremodi, inkludert en dedikert **terrengmodus** med innstillinger optimalisert for underlag med lav friksjon.
 
 ## Fjæring
 
@@ -45,6 +56,12 @@ AUDI E7X har adaptivt fjæringssystem på tvers av alle varianter, med økt sofi
 - Justerbar kjørehøyde (foran og bak)
 - Maksimal bakkeklaring: 180 mm
 
-Fra **Pioneer Pro** og oppover legger **Audi Racecourse-chassispakken** til **CDC kontinuerlig dempingskontroll kombinert med luftfjæring**, som erstatter den standard adaptive demperoppsettet. Helalu-chassiset reduserer i tillegg fjærende masser. Denne pakken er inkludert som tidsbegrenset gave på Pioneer Pro, Pioneer quattro og oppover.
+Fra **Pioneer Pro** og oppover legger **Audi Track-level Chassis**-pakken til **CDC kontinuerlig dempingskontroll kombinert med luftfjæring**, som erstatter det standard adaptive demperoppsettet. Helalu-chassiset reduserer i tillegg fjærende masser. Denne pakken er inkludert som tidsbegrenset gave på Pioneer Pro, Pioneer quattro og oppover.
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/chassis_4e086_st.webp" width="1920" height="1080" title="AUDI E7X chassis" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/chassis_d2e7e_st.webp" width="1920" height="1080" title="AUDI E7X chassis" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/batterypack_94a4c_st.webp" width="1920" height="1080" title="AUDI E7X batteripakke" >}}
 
 {{<children description="true" />}}

--- a/content/models/e7x/exterior/_index.md
+++ b/content/models/e7x/exterior/_index.md
@@ -14,9 +14,10 @@ The AUDI E7X exterior design is directly inspired by the AUDI E SUV concept, tra
 
 Key design characteristics of the E7X exterior include:
 
-- Clean, monolithic surfaces with a calm yet striking appearance
-- Upright front end with a distinctive black wraparound design element
-- Vertically arranged **digital Matrix LED headlights**
+- **AUDI Light Frame** — a wraparound front architecture with over **1,000 individually controllable triangular LED elements**, creating a distinctive light identity at the front and sides
+- Vertically arranged **digital Matrix LED headlights** with lane and position marking capability
+- Black wraparound loop integrating lights and sensors
+- **Frameless doors** for a clean, uninterrupted body surface
 - Short overhangs and powerfully sculpted wheel arches
 - SUV body style with a commanding road presence
 
@@ -28,10 +29,8 @@ The E7X occupies a commanding footprint in the large premium SUV segment:
 
 - Length: 5,049 mm
 - Width: 1,997 mm (excluding mirrors)
-- Height: 1,708 mm
+- Height: 1,710 mm
 - Wheelbase: 3,060 mm
-- Track width front: 1,705 mm
-- Track width rear: 1,717 mm
 - Turning circle: 10.3 m
 
 ## Paint colors

--- a/content/models/e7x/exterior/_index.md
+++ b/content/models/e7x/exterior/_index.md
@@ -49,9 +49,9 @@ The AUDI E7X is available in six exterior paint colors:
 
 The E7X features **vertically arranged digital Matrix LED headlights** as standard. From the **Pioneer Smart Long-Range** upwards, the headlights are upgraded to the **Star Diamond Light Blade Upgrade Kit** (星钻光幕光刀升级套装, value ¥22,000) — incorporating DLP (Digital Light Projection) high-definition digital projection headlights, 8 programmable welcome and farewell light animations, and a linked lighting design across the full front light signature. On Pioneer Smart Long-Range and Pioneer quattro this kit is a limited-time gift; on the **Flagship quattro** it is core standard equipment.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/headlights_32ac7_st.webp" width="3000" height="2000" title="AUDI E7X digital Matrix LED headlights" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/headlights_32ac7_st.webp" width="1070" height="630" title="AUDI E7X digital Matrix LED headlights" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/headlights_e1462_st.webp" width="3000" height="2000" title="AUDI E7X Star Diamond Light Blade" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/headlights_e1462_st.webp" width="1600" height="900" title="AUDI E7X Star Diamond Light Blade" >}}
 
 ## Wheels
 
@@ -60,7 +60,7 @@ The E7X features **vertically arranged digital Matrix LED headlights** as standa
 - **Pioneer Smart Long-Range**: 21-inch 8-spoke black alloy (included, CLTC 751 km) or 22-inch 8-spoke high-spec alloy with Brembo sport calipers and Audi floating hub covers (¥5,500 extra, CLTC 730 km)
 - **Pioneer quattro**: 21-inch 8-spoke black alloy (included, CLTC 635 km) or 22-inch 8-spoke black alloy with Brembo sport calipers and Audi floating hub covers (¥5,500 extra, CLTC 615 km)
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/wheels_fde4a_st.webp" width="3000" height="2000" title="AUDI E7X wheels" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/wheels_fde4a_st.webp" width="1920" height="1080" title="AUDI E7X wheels" >}}
 
 ## Mirrors
 
@@ -70,22 +70,22 @@ From the **Pioneer Pro** upwards, the E7X comes standard with **digital camera-b
 
 The **Smart Electrochromic Panoramic Roof** features a large 2,195 m² glass area with electronically adjustable tinting, blocking 99.99% of UV, 99.9% of infrared and 99.85% of solar radiation.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_633f7_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_633f7_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_b924f_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_b924f_st.webp" width="1070" height="630" title="AUDI E7X" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_51a75_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_51a75_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_04d70_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_04d70_st.webp" width="1600" height="900" title="AUDI E7X" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/taillights_c2728_st.webp" width="3000" height="2000" title="AUDI E7X taillights" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/taillights_c2728_st.webp" width="1600" height="900" title="AUDI E7X taillights" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_71ea3_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_71ea3_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/dynamic_5546d_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/dynamic_5546d_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/dynamic_73a56_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/dynamic_73a56_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/lifestyle_e7f2b_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/lifestyle_e7f2b_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
 {{<children description="true" />}}

--- a/content/models/e7x/exterior/_index.nb.md
+++ b/content/models/e7x/exterior/_index.nb.md
@@ -14,9 +14,10 @@ Eksteriørdesignet til AUDI E7X er direkte inspirert av AUDI E SUV-konseptet og 
 
 Viktige designtrekk i E7X-eksteriøret inkluderer:
 
-- Rene, monolittiske flater med et rolig, men markant uttrykk
-- Oppreist front med et karakteristisk sort, omsluttende designelement
-- Vertikalt arrangerte **digitale Matrix LED-frontlykter**
+- **AUDI Light Frame** — en omsluttende frontlysarkitektur med over **1 000 individuelt styrbare trekantede LED-elementer**, som skaper en særegen lysidentitet foran og på sidene
+- Vertikalt arrangerte **digitale Matrix LED-frontlykter** med fil- og posisjonsmarkering
+- Sort, omsluttende designelement som integrerer lykter og sensorer
+- **Dørløse rammer (frameless doors)** for et rent, uavbrutt karosseriuttrykk
 - Korte overheng og kraftig modellerte hjulbuer
 - SUV-karosseri med en imponerende tilstedeværelse på veien
 
@@ -28,10 +29,8 @@ E7X har et dominerende fotavtrykk i segmentet for store premium-SUV-er:
 
 - Lengde: 5 049 mm
 - Bredde: 1 997 mm (uten speil)
-- Høyde: 1 708 mm
+- Høyde: 1 710 mm
 - Akselavstand: 3 060 mm
-- Sporvidde foran: 1 705 mm
-- Sporvidde bak: 1 717 mm
 - Svingdiameter: 10,3 m
 
 ## Lakkfarger
@@ -49,12 +48,18 @@ AUDI E7X er tilgjengelig i seks eksteriørfarger:
 
 E7X har **vertikalt arrangerte digitale Matrix LED-frontlykter** som standard. Fra **Pioneer Smart Long-Range** og oppover oppgraderes frontlyktene til **Star Diamond Light Blade oppgraderingssettet** (星钻光幕光刀升级套装, verdi ¥22 000) — med DLP (Digital Light Projection) høyoppløselige digitale projeksjonslykt, 8 programmerbare velkomst- og avskjedsanimasjoner og synkronisert lysstyring over hele frontlyktprofilen. På Pioneer Smart Long-Range og Pioneer quattro er settet en tidsbegrenset gave; på **Flagship quattro** er det kjerneutstyr.
 
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/headlights_32ac7_st.webp" width="1070" height="630" title="AUDI E7X digitale Matrix LED-frontlykter" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/headlights_e1462_st.webp" width="1600" height="900" title="AUDI E7X Star Diamond Light Blade" >}}
+
 ## Hjul
 
 - **Pioneer**: 21-tommers 8-eikede aluminiumsfelger (sølvfinish, CLTC 705 km)
 - **Pioneer Pro**: 21-tommers 8-eikede sort-lakerte aluminiumsfelger (CLTC 691 km)
 - **Pioneer Smart Long-Range**: 21-tommers 8-eikede sort-lakerte aluminiumsfelger (inkludert, CLTC 751 km) eller 22-tommers 8-eikede høyspesifikasjonsfelger med Brembo sportskalipers og Audi flytende hjulkapseldekor (¥5 500 ekstra, CLTC 730 km)
 - **Pioneer quattro**: 21-tommers 8-eikede sort-lakerte aluminiumsfelger (inkludert, CLTC 635 km) eller 22-tommers 8-eikede sort-lakerte aluminiumsfelger med Brembo sportskalipers og Audi flytende hjulkapseldekor (¥5 500 ekstra, CLTC 615 km)
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/wheels_fde4a_st.webp" width="1920" height="1080" title="AUDI E7X hjul" >}}
 
 ## Sidespeil
 
@@ -64,8 +69,22 @@ Fra **Pioneer Pro** og oppover leveres E7X med standard **digitale kamerabaserte
 
 Det **intelligente elektrokromiske panoramataket** har et stort glassareal på 2 195 m² med elektronisk justerbar farging, som blokkerer 99,99 % UV, 99,9 % infrarødt og 99,85 % solstråling.
 
-{{< sitefiguresized thumb="models/e7x/exterior/exterior_2_st.webp" width="3000" height="2250" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_633f7_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
-{{< sitefiguresized thumb="models/e7x/exterior/exterior_3_st.webp" width="3000" height="2250" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_b924f_st.webp" width="1070" height="630" title="AUDI E7X" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_51a75_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_04d70_st.webp" width="1600" height="900" title="AUDI E7X" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/taillights_c2728_st.webp" width="1600" height="900" title="AUDI E7X baklykter" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/exterior_71ea3_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/dynamic_5546d_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/dynamic_73a56_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/lifestyle_e7f2b_st.webp" width="1920" height="1080" title="AUDI E7X" >}}
 
 {{<children description="true" />}}

--- a/content/models/e7x/interior/_index.md
+++ b/content/models/e7x/interior/_index.md
@@ -83,7 +83,10 @@ From the Pioneer Pro upwards, the **Audi Smart Living Room** package transforms 
 The Flagship quattro replaces the Smart Living Room with the **Palace-Class Zero-Pressure Four-Seat First-Class Cabin** (殿堂级零压四座头等舱, value ¥59,000) — a significantly elevated rear experience:
 
 - **21.4-inch QD Mini LED rear ceiling screen** — star screen, smart four-season cooler/warmer box
-- **Dual rear zero-gravity seats** — both rear outboard seats recline to true zero-gravity positions, vs single front passenger zero-G on lower variants
+- **Dual rear zero-gravity seats** — both rear outboard seats recline to **120°** (near-flat), vs single front passenger zero-G on lower variants
+- **23-point pneumatic adjustment** with airbag-based support shaping (per seat)
+- **16-point massage function**
+- Electric extendable footrest with up to **400 mm of travel**
 
 ## Health certification
 
@@ -91,18 +94,17 @@ The entire cabin carries **OEKO-TEX® mother & baby grade health certification**
 
 ## Screens and user interface
 
-The AUDI E7X features an extensive multi-screen cabin:
+The AUDI E7X features a full-width multi-screen cabin architecture:
 
-- **Digital driver display**
-- **Central infotainment screen**
-- **Audi wide-area display** (part of Super Sense Smart Package)
-- **21.4-inch QD Mini LED rear ceiling screen** — Apple XDR-grade panel, supports wired/wireless projection from Switch, PS5 and other devices (included as limited-time gift)
+- **27-inch 4K panoramic dashboard display** — a single curved screen spanning the full instrument and infotainment width
+- **21.4-inch QD Mini LED rear ceiling screen** — deploys from the headliner, Apple XDR-grade, supports wired/wireless projection from Switch, PS5 and other devices
 - **Rear center console touchscreen**
 - Optional **head-up display**
-- **Voice control** (Audi Assistant) as standard
 - **Audi Smart Island** — smart interaction hub
 
-The cabin does not support Android Auto or gesture control, reflecting AUDI's focus on its own deeply integrated China-specific software ecosystem.
+**AUDI Assistant 2.0** — the voice and AI interface, co-developed with **ByteDance**. Delivers significantly enhanced conversational AI capability and deep integration with Chinese digital services, apps and payment platforms. Standard on all variants.
+
+The cabin does not support Android Auto, reflecting AUDI's focus on its own deeply integrated China-specific software ecosystem.
 
 {{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_a77e9_st.webp" width="1070" height="630" title="AUDI E7X interior" >}}
 

--- a/content/models/e7x/interior/_index.md
+++ b/content/models/e7x/interior/_index.md
@@ -8,7 +8,7 @@ weight: 5
 
 The AUDI E7X interior is designed around the tech-savvy Chinese customer, combining premium materials and craftsmanship with a deeply digital and connected cabin experience.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_2896c_st.webp" width="3000" height="2000" title="AUDI E7X interior" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_2896c_st.webp" width="1920" height="1080" title="AUDI E7X interior" >}}
 
 ## Seating configuration
 
@@ -23,15 +23,15 @@ The front seats offer a driver and passenger seat configuration with:
 - Optional seat ventilation
 - Optional massage function
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/frontseats_231fc_st.webp" width="3000" height="2000" title="AUDI E7X front seats" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/frontseats_231fc_st.webp" width="1920" height="1080" title="AUDI E7X front seats" >}}
 
 ### Rear seats
 
 The rear features a three-seat bench providing generous space thanks to the 3,060 mm wheelbase.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/secondrowseats_13d2f_st.webp" width="3000" height="2000" title="AUDI E7X rear seats" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/secondrowseats_13d2f_st.webp" width="1920" height="1080" title="AUDI E7X rear seats" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/secondrowseats_b01f2_st.webp" width="3000" height="2000" title="AUDI E7X Flagship quattro rear seats" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/secondrowseats_b01f2_st.webp" width="1920" height="1080" title="AUDI E7X Flagship quattro rear seats" >}}
 
 ## Interior colors and inlays
 
@@ -104,12 +104,12 @@ The AUDI E7X features an extensive multi-screen cabin:
 
 The cabin does not support Android Auto or gesture control, reflecting AUDI's focus on its own deeply integrated China-specific software ecosystem.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_a77e9_st.webp" width="3000" height="2000" title="AUDI E7X interior" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_a77e9_st.webp" width="1070" height="630" title="AUDI E7X interior" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/screens_ff4dc_st.webp" width="3000" height="2000" title="AUDI E7X screens" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/screens_ff4dc_st.webp" width="1070" height="630" title="AUDI E7X screens" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_44525_st.webp" width="3000" height="2000" title="AUDI E7X interior" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_44525_st.webp" width="1920" height="1080" title="AUDI E7X interior" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_ce202_st.webp" width="3000" height="2000" title="AUDI E7X interior" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_ce202_st.webp" width="1600" height="900" title="AUDI E7X interior" >}}
 
 {{<children description="true" />}}

--- a/content/models/e7x/interior/_index.nb.md
+++ b/content/models/e7x/interior/_index.nb.md
@@ -8,7 +8,7 @@ weight: 5
 
 Interiøret i AUDI E7X er designet med den teknologibevisste kinesiske kunden i fokus, og kombinerer premiummaterialer og håndverk med en gjennomdigital og tilkoblet kabinopplevelse.
 
-{{< sitefiguresized thumb="models/e7x/exterior/exterior_4_st.webp" width="3000" height="2000" title="AUDI E7X" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_2896c_st.webp" width="1920" height="1080" title="AUDI E7X interiør" >}}
 
 ## Setekonfigurasjon
 
@@ -23,9 +23,15 @@ Forstene tilbyr en fører- og passasjersete-konfigurasjon med:
 - Valgfri seteventilasjon
 - Valgfri massasjefunksjon
 
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/frontseats_231fc_st.webp" width="1920" height="1080" title="AUDI E7X forseter" >}}
+
 ### Bakseter
 
 Bak er det en trebenkrad som gir god plass takket være den lange akselavstanden på 3 060 mm.
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/secondrowseats_13d2f_st.webp" width="1920" height="1080" title="AUDI E7X bakseter" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/secondrowseats_b01f2_st.webp" width="1920" height="1080" title="AUDI E7X Flagship quattro bakseter" >}}
 
 ## Interiørfarger og innlegg
 
@@ -77,25 +83,35 @@ Fra Pioneer Pro og oppover transformerer **Audi Smart Living Room**-pakken bakse
 Flagship quattro erstatter Smart Living Room med **Palassnivå zero-press fire-seters førsteklasseskabin** (殿堂级零压四座头等舱, verdi ¥59 000) — en betydelig oppgradert baksetiopplevelse:
 
 - **21,4-tommers QD Mini LED-takskjerm** — stjernehimmelpanel, smart fire-sesonger kjøle-/varmeboks
-- **Doble bakre null-tyngdekraft-seter** — begge de bakre yttersetene kan legges helt ned i ekte null-tyngdekraft-posisjon, mot ett forsetepassasjersete på lavere varianter
+- **Doble bakre null-tyngdekraft-seter** — begge de bakre yttersetene kan legges ned til **120°** (nær flat posisjon), mot ett forsetepassasjersete på lavere varianter
+- **23-punkts pneumatisk justeringssystem** med luftputebasert støtteforming (per sete)
+- **16-punkts massasjefunksjon**
+- Elektrisk uttrekkbar fotstøtte med opptil **400 mm rekkevidde**
 
-## Helsesertifsering
+## Helsesertifisering
 
 Hele kabinen har **OEKO-TEX® mor og barn-nivå helsesertifisering**, som dekker seter, sikkerhetsbelte, ratt, instrumentpanel, trimplater, kopholdere og mer — alle verifisert mot over 1 000 skadelige stoffer (verdi ¥8 000).
 
 ## Skjermer og brukergrensesnitt
 
-AUDI E7X har et omfattende flerskjermssystem i kabinen:
+AUDI E7X har et flerskjermssystem som dekker hele kabinbredden:
 
-- **Digitalt instrumentpanel**
-- **Sentral infotainmentskjerm**
-- **Audi bred displayskjerm** (del av Super Sense Smart-pakken)
-- **21,4-tommers QD Mini LED-takskjerm** — Apple XDR-panelkvalitet, støtter kablet/trådløs speiling fra bl.a. Switch og PS5 (inkludert som tidsbegrenset gave)
+- **27-tommers 4K panoramadisplay** — en enkelt buet skjerm som strekker seg over hele instrument- og infotainmentbredden
+- **21,4-tommers QD Mini LED-takskjerm** — foldes ned fra taket, Apple XDR-panelkvalitet, støtter kablet/trådløs speiling fra bl.a. Switch og PS5
 - **Berøringsskjerm i bakre midtkonsoll**
 - Valgfri **head-up display**
-- **Stemmestyring** (Audi-assistent) som standardutstyr
 - **Audi Smart Island** — intelligent interaksjonshub
 
-Kabinen støtter ikke Android Auto eller bevegelseskontroll, noe som gjenspeiler AUDIs fokus på sitt eget dyptintegrerte, Kina-spesifikke programvareøkosystem.
+**AUDI Assistant 2.0** — stemme- og AI-grensesnittet, co-utviklet med **ByteDance**. Leverer betydelig forbedret konversasjons-AI og dyp integrasjon med kinesiske digitale tjenester, apper og betalingsplattformer. Standardutstyr på alle varianter.
+
+Kabinen støtter ikke Android Auto, noe som gjenspeiler AUDIs fokus på sitt eget dyptintegrerte, Kina-spesifikke programvareøkosystem.
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_a77e9_st.webp" width="1070" height="630" title="AUDI E7X interiør" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/screens_ff4dc_st.webp" width="1070" height="630" title="AUDI E7X skjermer" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_44525_st.webp" width="1920" height="1080" title="AUDI E7X interiør" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_pioneer_quattro/interior_ce202_st.webp" width="1600" height="900" title="AUDI E7X interiør" >}}
 
 {{<children description="true" />}}

--- a/content/models/e7x/technology/_index.md
+++ b/content/models/e7x/technology/_index.md
@@ -40,9 +40,9 @@ The AUDI E7X features a comprehensive sensor suite for driver assistance and par
 
 **Radar sensors:** Forward-facing radar for adaptive cruise control and emergency braking functionality.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/sensors_2c6fa_st.webp" width="3000" height="2000" title="AUDI E7X sensor suite" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/sensors_2c6fa_st.webp" width="1920" height="1080" title="AUDI E7X sensor suite" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/camera_d1e99_st.webp" width="3000" height="2000" title="AUDI E7X camera" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/camera_d1e99_st.webp" width="1600" height="900" title="AUDI E7X camera" >}}
 
 ## Lights
 
@@ -59,7 +59,7 @@ From the **Pioneer Pro** upwards, the **BOSE Performance sound system** is inclu
 
 The **Flagship quattro** receives an upgraded **9.1.4.8 BOSE Performance** configuration — a 9.1.4.8 immersive audio architecture with the same four world-first technologies and DSP power, but with a more expansive speaker arrangement (value ¥15,000).
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/speakers_cc864_st.webp" width="3000" height="2000" title="AUDI E7X BOSE Performance speaker" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/speakers_cc864_st.webp" width="1070" height="630" title="AUDI E7X BOSE Performance speaker" >}}
 
 ## Rear-wheel steering
 
@@ -86,8 +86,8 @@ All four doors feature **electric soft-close** — push gently and the door pull
 
 The E7X is built on AUDI and SAIC's **Advanced Digitized Platform**, enabling seamless integration with China's digital infrastructure. Voice control (Audi Assistant) is standard equipment. The cabin features a multi-screen setup with Audi Smart Island, optimized for connected services in the Chinese market.
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/technology_4ba6e_st.webp" width="3000" height="2000" title="AUDI E7X technology" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/technology_4ba6e_st.webp" width="1070" height="630" title="AUDI E7X technology" >}}
 
-{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/technology_2207b_st.webp" width="3000" height="2000" title="AUDI E7X technology" >}}
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/technology_2207b_st.webp" width="1920" height="1080" title="AUDI E7X technology" >}}
 
 {{<children description="true" />}}

--- a/content/models/e7x/technology/_index.md
+++ b/content/models/e7x/technology/_index.md
@@ -10,6 +10,19 @@ The AUDI E7X is built around a deeply connected, intelligent technology platform
 
 {{< sitefiguresized thumb="models/e7x/exterior/exterior_5_st.webp" width="3000" height="1688" title="AUDI E7X" >}}
 
+## AUDI 360 Driving Assist
+
+The E7X features the **AUDI 360 Driving Assist** system, co-developed with **Momenta** and equipped with a **lidar sensor** for enhanced environmental perception at long range and in complex scenarios.
+
+The system covers:
+
+- Highway driving assistance (longitudinal and lateral control)
+- Urban driving assistance
+- Memory parking for garages and parking lots
+- Non-standard parking capability and head-in parking
+- Dynamic warning indicators projected onto the road surface
+- Predictive distance warnings for vehicles ahead
+
 ## Driver assistance systems
 
 The E7X comes equipped with an extensive suite of driver assistance features as standard:
@@ -50,14 +63,14 @@ The E7X features **vertically arranged digital Matrix LED headlights** as a key 
 
 ## Sound system
 
-From the **Pioneer Pro** upwards, the **BOSE Performance sound system** is included:
+The **Bose Performance Series** sound system delivers **26 speakers** with 360° spatial audio across the cabin. Features include:
 
 - Four world-first audio technologies
-- Immersive audio architecture
-- DSP processing power up to 2,000 MIPS
+- 360° spatial audio architecture
+- DSP processing up to 2,000 MIPS
 - Intelligent road noise isolation
 
-The **Flagship quattro** receives an upgraded **9.1.4.8 BOSE Performance** configuration — a 9.1.4.8 immersive audio architecture with the same four world-first technologies and DSP power, but with a more expansive speaker arrangement (value ¥15,000).
+The Flagship quattro receives an upgraded **9.1.4.8 BOSE Performance** configuration (value ¥15,000).
 
 {{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/speakers_cc864_st.webp" width="1070" height="630" title="AUDI E7X BOSE Performance speaker" >}}
 

--- a/content/models/e7x/technology/_index.nb.md
+++ b/content/models/e7x/technology/_index.nb.md
@@ -10,6 +10,19 @@ AUDI E7X er bygget rundt en dypt tilkoblet, intelligent teknologiplattform utvik
 
 {{< sitefiguresized thumb="models/e7x/exterior/exterior_5_st.webp" width="3000" height="1688" title="AUDI E7X" >}}
 
+## AUDI 360 Driving Assist
+
+E7X har **AUDI 360 Driving Assist**-systemet, co-utviklet med **Momenta** og utstyrt med **lidar-sensor** for forbedret omgivelsespersepsjon på lang avstand og i komplekse situasjoner.
+
+Systemet dekker:
+
+- Kjøreassistanse på motorvei (langsgående og tverrgående styring)
+- Kjøreassistanse i by
+- Minneparkering for parkeringshus og parkeringsplasser
+- Ikke-standard parkering og frontparkeringsevne
+- Dynamiske varselindikatorer projisert på veioverflaten
+- Prediktive avstandsvarsler for kjøretøy foran
+
 ## Førerassistansesystemer
 
 E7X leveres med en omfattende pakke med førerassistansefunksjoner som standardutstyr:
@@ -40,20 +53,26 @@ AUDI E7X har et omfattende sensorsystem for førerassistanse og parkering:
 
 **Radarsensorer:** Fremovervendt radar for adaptiv fartsholder og nødbremsefunksjonalitet.
 
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/sensors_2c6fa_st.webp" width="1920" height="1080" title="AUDI E7X sensorsystem" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/camera_d1e99_st.webp" width="1600" height="900" title="AUDI E7X kamera" >}}
+
 ## Lykter
 
 E7X har **vertikalt arrangerte digitale Matrix LED-frontlykter** som et sentralt eksterior- og teknologifremhev, med presis strålestyring og dynamiske lysfunksjoner.
 
 ## Lydsystem
 
-Fra **Pioneer Pro** og oppover er **BOSE Performance-lydsystemet** inkludert:
+**Bose Performance Series**-lydsystemet leverer **26 høyttalere** med 360° romlig lyd i kabinen. Funksjoner inkluderer:
 
 - Fire verdensførsteteknologier innen lyd
-- Oppslukende lydarkitektur
+- 360° romlig lydarkitektur
 - DSP-prosessering opptil 2 000 MIPS
 - Intelligent isolasjon mot veistøy
 
-**Flagship quattro** mottar en oppgradert **9.1.4.8 BOSE Performance**-konfigurasjon — en 9.1.4.8 oppslukende lydarkitektur med de samme fire verdensførsteteknologiene og DSP-kraft, men med et mer ekspansivt høyttaleroppsett (verdi ¥15 000).
+**Flagship quattro** mottar en oppgradert **9.1.4.8 BOSE Performance**-konfigurasjon (verdi ¥15 000).
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/speakers_cc864_st.webp" width="1070" height="630" title="AUDI E7X BOSE Performance høyttaler" >}}
 
 ## Bakhjulsstyring
 
@@ -78,6 +97,10 @@ Alle fire dørene har **elektriske sugedører** — skyv lett og døren lukker s
 
 ## Tilkobling
 
-E7X er bygget på AUDI og SAICs **Advanced Digitized Platform**, som muliggjør sømløs integrasjon med Kinas digitale infrastruktur. Stemmestyring (Audi-assistent) er standardutstyr. Kabinen har et flersskjermoppsett med Audi Smart Island, optimert for tilkoblede tjenester i det kinesiske markedet.
+E7X er bygget på AUDI og SAICs **Advanced Digitized Platform**, som muliggjør sømløs integrasjon med Kinas digitale infrastruktur. Stemmestyring (Audi-assistent) er standardutstyr. Kabinen har et flerskjermoppsett med Audi Smart Island, optimert for tilkoblede tjenester i det kinesiske markedet.
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/technology_4ba6e_st.webp" width="1070" height="630" title="AUDI E7X teknologi" >}}
+
+{{< evkxfiguresized thumb="models/audi/e7x/e7x_flagship_quattro/technology_2207b_st.webp" width="1920" height="1080" title="AUDI E7X teknologi" >}}
 
 {{<children description="true" />}}

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -150,10 +150,16 @@
   translation: Audi Q8 e-tron is now official. With an improved range of up to 44%, reduced consumption by up to 9%, and a new design. Learn all about the six variants!
 
 - id: frontpage-article-e7x-title
-  translation: AUDI E7X debuts 2026
+  translation: AUDI E7X sales have started
 
 - id: frontpage-article-e7x-synopsis
-  translation: China-exclusive fully electric premium SUV developed with SAIC, debuting at Auto China 2026 with cutting-edge technology and localized features.
+  translation: China-exclusive fully electric premium SUV — 900V, 4C charging, up to 751 km CLTC range. Sales launched in China H1 2026.
+
+- id: frontpage-article-q4facelift2026-title
+  translation: Audi Q4 e-tron facelift 2026
+
+- id: frontpage-article-q4facelift2026-synopsis
+  translation: More range, faster charging, bidirectional V2L and V2H, a new digital interior, and second-generation OLED rear lights. The Q4 e-tron gets its biggest upgrade yet.
 
 - id: frontpage-article-audiconceptc-title
   translation: Audi Concept C world premiere

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -148,10 +148,16 @@
   translation: Audi Q8 e-tron er nå offisiell. Med forbedret rekkevidde med opptil 44 %, redusert forbruk med opptil 9 % og ny design. Lær alt om de seks variantene!
 
 - id: frontpage-article-e7x-title
-  translation: AUDI E7X debuterer 2026
+  translation: AUDI E7X er nå til salgs
 
 - id: frontpage-article-e7x-synopsis
-  translation: Kina-eksklusiv helektrisk premium SUV utviklet med SAIC, debuterer på Auto China 2026 med banebrytende teknologi og lokaltilpassede funksjoner.
+  translation: Kina-eksklusiv helektrisk premium SUV — 900V, 4C-lading, opptil 751 km CLTC rekkevidde. Salget er i gang i Kina første halvår 2026.
+
+- id: frontpage-article-q4facelift2026-title
+  translation: Audi Q4 e-tron facelift 2026
+
+- id: frontpage-article-q4facelift2026-synopsis
+  translation: Mer rekkevidde, raskere lading, toveis V2L og V2H, nytt digitalt interiør og andre generasjons OLED-baklykter. Q4 e-tron får sin største oppdatering noensinne.
 
 - id: frontpage-article-audiconceptc-title
   translation: Audi Concept C verdenspremiere

--- a/themes/ehga-tailwind/layouts/partials/carousel.html
+++ b/themes/ehga-tailwind/layouts/partials/carousel.html
@@ -8,7 +8,7 @@
 			<button type="button" onclick="currentSlide(4)" class="w-3 h-3 rounded-full bg-white bg-opacity-60 hover:bg-opacity-100 transition-all carousel-dot" aria-label="Slide 4"></button>
 			<button type="button" onclick="currentSlide(5)" class="w-3 h-3 rounded-full bg-white bg-opacity-60 hover:bg-opacity-100 transition-all carousel-dot" aria-label="Slide 5"></button>
 		</div>
-		
+
 		<!-- Carousel slides -->
 		<div class="flex transition-transform duration-500 ease-in-out" id="carousel-wrapper">
 			<div class="w-full flex-shrink-0 relative carousel-slide">
@@ -18,6 +18,15 @@
 				<div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black via-black/50 to-transparent text-white p-6">
 					<h4 class="text-xl md:text-2xl font-bold mb-2">{{T "frontpage-article-e7x-title"}}</h4>
 					<p class="hidden md:block text-sm md:text-base opacity-90">{{T "frontpage-article-e7x-synopsis"}}</p>
+				</div>
+			</div>
+			<div class="w-full flex-shrink-0 relative carousel-slide">
+				<a href="{{ with .Site.GetPage `/articles/q4etronfacelift2026/`}}{{.RelPermalink}}{{end}}">
+					<img src="https://media.evkx.net/multimedia/models/audi/q4_e-tron/q4_e-tron_quattro_performance/exterior_5b737_st.webp" class="w-full h-[300px] sm:h-[400px] md:h-[500px] lg:h-[600px] xl:h-[720px] object-cover" alt="Audi Q4 e-tron facelift 2026">
+				</a>
+				<div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black via-black/50 to-transparent text-white p-6">
+					<h4 class="text-xl md:text-2xl font-bold mb-2">{{T "frontpage-article-q4facelift2026-title"}}</h4>
+					<p class="hidden md:block text-sm md:text-base opacity-90">{{T "frontpage-article-q4facelift2026-synopsis"}}</p>
 				</div>
 			</div>
 			<div class="w-full flex-shrink-0 relative carousel-slide">
@@ -47,26 +56,8 @@
 					<p class="hidden md:block text-sm md:text-base opacity-90">{{T "frontpage-article-q6sportbackpremiere-synopsis"}}</p>
 				</div>
 			</div>
-			<div class="w-full flex-shrink-0 relative carousel-slide">
-				<a href="{{ with .Site.GetPage `/articles/a6worldpremiere/`}}{{.RelPermalink}}{{end}}">
-					<img src="https://media.evkx.net/ehga/models/a6-e-tron/variants/variants_1_mt.webp" class="w-full h-[300px] sm:h-[400px] md:h-[500px] lg:h-[600px] xl:h-[720px] object-cover" alt="A6 World Premiere">
-				</a>
-				<div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black via-black/50 to-transparent text-white p-6">
-					<h4 class="text-xl md:text-2xl font-bold mb-2">{{T "frontpage-article-a6premiere-title"}}</h4>
-					<p class="hidden md:block text-sm md:text-base opacity-90">{{T "frontpage-article-a6premiere-synopsis"}}</p>
-				</div>
-			</div>
-			<div class="w-full flex-shrink-0 relative carousel-slide">
-				<a href="{{ with .Site.GetPage `/articles/etrongtrefresh/`}}{{.RelPermalink}}{{end}}">
-					<img src="https://media.evkx.net/ehga/models/e-tron-gt/variants/variants_2_mt.webp" class="w-full h-[300px] sm:h-[400px] md:h-[500px] lg:h-[600px] xl:h-[720px] object-cover" alt="e-tron GT Refresh">
-				</a>
-				<div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black via-black/50 to-transparent text-white p-6">
-					<h4 class="text-xl md:text-2xl font-bold mb-2">{{T "frontpage-article-etronggtrefresh-title"}}</h4>
-					<p class="hidden md:block text-sm md:text-base opacity-90">{{T "frontpage-article-etronggtrefresh-synopsis"}}</p>
-				</div>
-			</div>
 		</div>
-		
+
 		<!-- Navigation arrows -->
 		<button type="button" onclick="prevSlide()" class="absolute left-4 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 hover:bg-opacity-75 text-white p-2 rounded-full transition-all z-10">
 			<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -88,13 +79,13 @@ const totalSlides = document.querySelectorAll('.carousel-slide').length;
 function showSlide(index) {
     const wrapper = document.getElementById('carousel-wrapper');
     const dots = document.querySelectorAll('.carousel-dot');
-    
+
     // Ensure index is within bounds
     currentSlideIndex = (index + totalSlides) % totalSlides;
-    
+
     // Move to the correct slide
     wrapper.style.transform = `translateX(-${currentSlideIndex * 100}%)`;
-    
+
     // Update dot indicators
     dots.forEach((dot, i) => {
         dot.classList.toggle('active', i === currentSlideIndex);


### PR DESCRIPTION
## Summary

- **E7X main article rewritten** to post-launch with all confirmed specs from the Auto China 2026 world premiere press release
- **E7X all section files updated** (exterior, interior, drivetrain, technology) — EN and NO
- **Norwegian section files synced** to match updated English content
- **Frontpage carousel refreshed**: E7X sales-started slide + new Q4 facelift 2026 slide, two oldest slides removed

## E7X changes (from world premiere press release)

- E5 Sportback named **China Car of the Year 2026**
- Three-model AUDI roadmap: E5 → E7X → all-electric sedan (2027 premiere)
- **AUDI Light Frame** — 1,000+ individually controllable triangular LED elements + frameless doors
- Height corrected to **1,710 mm**; all image dimensions fixed from `e7x.json`
- **27-inch 4K panoramic dashboard display**
- **AUDI Assistant 2.0** co-developed with **ByteDance**
- **109 kWh** battery option, **900V** architecture, **4C charging**, 10–80% in **13 minutes**
- **All-wheel steering** standard across all variants + off-road mode
- **Lidar + Momenta** for AUDI 360 Driving Assist
- **Bose 26-speaker** system; executive rear seat: 120° recline, 23-airbag pneumatics, 16-pt massage, 400 mm footrest
- Production at **Anting, Shanghai**

## Norwegian section sync

All four E7X section NB files updated to match the English versions:
- Drivetrain: 900V/4C/13 min, 109 kWh, all-wheel steering, Track-level Chassis naming, evkxfiguresized images
- Exterior: AUDI Light Frame, frameless doors, height 1,710 mm, full image gallery
- Interior: 27" 4K display, AUDI Assistant 2.0/ByteDance, complete Flagship quattro seat specs, images
- Technology: AUDI 360 Driving Assist + Lidar/Momenta section, Bose 26 speakers, images

## Frontpage carousel

- Slide 1: **AUDI E7X sales have started** (updated text)
- Slide 2: **Audi Q4 e-tron facelift 2026** (new — links to q4etronfacelift2026 article)
- Slides 3–5: Audi Concept C, E5 Sportback, Q6 Sportback Premiere (kept)
- Removed: A6 World Premiere + e-tron GT Refresh (two oldest)
- i18n EN+NO updated with new/changed carousel translation keys

## Test plan

- [ ] E7X pages (EN + NO) show post-launch content with correct specs
- [ ] All E7X section images render with correct aspect ratios
- [ ] Frontpage carousel shows E7X sales slide first, Q4 facelift second
- [ ] Q4 facelift slide links to the correct article

🤖 Generated with [Claude Code](https://claude.com/claude-code)