### PR TITLE
Fix Hugo 0.153 multilingual build

### DIFF
--- a/layouts/partials/headstandard.html
+++ b/layouts/partials/headstandard.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="{{ "css/photoswipe.css" | relURL }}">
   <script src="{{ "js/ehga-site.js" | relURL }}" defer></script>
   {{- $currentPage := . -}}
-  {{- if .Site.IsMultiLingual -}}
+  {{- if gt (len .Site.Languages) 1 -}}
     {{- range .AllTranslations -}}
       <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}">
     {{- end -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -14,7 +14,7 @@
       <a class="site-nav__link" href="{{ with .Site.GetPage "/guides/" }}{{ .RelPermalink }}{{ end }}" {{ if eq $section "guides" }}aria-current="page"{{ end }}>{{ T "menu-guides" }}</a>
       <a class="site-nav__link" href="{{ with .Site.GetPage "/articles/" }}{{ .RelPermalink }}{{ end }}" {{ if eq $section "articles" }}aria-current="page"{{ end }}>{{ T "menu-articles" }}</a>
       <a class="site-nav__link site-nav__link--cta" href="{{ with .Site.GetPage "/compare/" }}{{ .RelPermalink }}{{ else }}/compare/{{ end }}" {{ if eq $section "compare" }}aria-current="page"{{ end }}>{{ if eq .Language.Lang "nb" }}Sammenlign{{ else }}Compare{{ end }}</a>
-      {{ if .Site.IsMultiLingual }}
+      {{ if gt (len .Site.Languages) 1 }}
       <div class="site-language">
         <button class="site-language__trigger" type="button" data-language-toggle aria-expanded="false">{{ upper .Language.Lang }} ↓</button>
         <div class="site-language__menu" data-language-menu hidden>


### PR DESCRIPTION
## Summary
- replace the removed .Site.IsMultiLingual property in the shared head and navbar partials
- use the configured language count so the templates remain compatible with both Hugo 0.122 and Hugo 0.153

## Verification
- hugo --minify --enableGitInfo=false completes successfully locally
- git diff --check passes

Merging this PR will trigger the GitHub Pages workflow on main.