### PR TITLE
Build native EHGA range calculator

### DIFF
--- a/data/ehga/models.yaml
+++ b/data/ehga/models.yaml
@@ -20,7 +20,7 @@
   charging: "125 kW"
 - slug: q6-e-tron
   title: Audi Q6 e-tron
-  evkx_id: d3459866-4569-409e-9697-5a841863f61a
+  evkx_id: 1dab2cfe-1d30-4338-836d-fa389d7d6d87
   image: https://media.evkx.net/ehga/models/q6-e-tron/q6dynamic_1_st.webp
   status: onsale
   market: europe
@@ -80,7 +80,7 @@
   charging: "420 kW"
 - slug: e7x
   title: AUDI E7X
-  evkx_id: 019e0866-3682-7f39-a580-7b47c1f835c8
+  evkx_id: 019e0866-46ee-7cce-b78e-f17b8e1faa55
   image: https://media.evkx.net/ehga/models/e7x/exterior/exterior_1_st.webp
   status: china
   market: china

--- a/layouts/partials/range-calculator.html
+++ b/layouts/partials/range-calculator.html
@@ -1,31 +1,117 @@
 {{ $page := .page }}
 {{ $model := .model }}
+{{ $nb := eq $page.Language.Lang "nb" }}
 {{ if $model.evkx_id }}
-<section class="band band--dark model-calculator">
+<section class="band band--dark model-calculator" id="range-calculator">
   <div class="container">
     <div class="model-calculator__heading">
       <div>
-        <div class="microlabel">{{ if eq $page.Language.Lang "nb" }}Rekkeviddeverktøy{{ else }}Range tool{{ end }}</div>
-        <h2 class="h-section">{{ if eq $page.Language.Lang "nb" }}Beregn rekkevidde under dine forhold{{ else }}Calculate range for your conditions{{ end }}</h2>
+        <div class="microlabel">{{ if $nb }}Rekkeviddeverktøy{{ else }}Range tool{{ end }}</div>
+        <h2 class="h-section">{{ if $nb }}Beregn rekkevidde under dine forhold{{ else }}Calculate range for your conditions{{ end }}</h2>
       </div>
-      <p>{{ if eq $page.Language.Lang "nb" }}Juster hastighet, temperatur, kjøreforhold og last. Beregningen bruker den samme kjøretøymodellen og motoren som EVKX.{{ else }}Adjust speed, temperature, road conditions and load. The calculation uses the same vehicle data and engine as EVKX.{{ end }}</p>
+      <p>{{ if $nb }}Juster hastighet, temperatur, veiforhold og bilens oppsett. Beregningen utføres av EVKX med data for denne modellen.{{ else }}Adjust speed, temperature, road conditions and vehicle setup. EVKX calculates the result using data for this model.{{ end }}</p>
     </div>
-    <div class="model-calculator__surface">
-      <div id="travel-calc-embed"
-           data-evkx-travel-calculator
-           data-ev-id="{{ $model.evkx_id }}"
-           data-api-base="https://evkx.net/api/"
-           data-asset-base="https://media.evkx.net/wwwroot/assets/travelcalculator/"
-           data-brand="Audi"
-           data-lang="{{ $page.Language.Lang }}"
-           data-color-scheme="dark"
-           aria-live="polite">
-        <p class="model-calculator__loading">{{ if eq $page.Language.Lang "nb" }}Laster rekkeviddekalkulator…{{ else }}Loading range calculator…{{ end }}</p>
-      </div>
-      <noscript><p>{{ if eq $page.Language.Lang "nb" }}JavaScript må være aktivert for å bruke kalkulatoren.{{ else }}JavaScript is required to use the calculator.{{ end }}</p></noscript>
+
+    <div class="model-calculator__surface"
+         data-ehga-range-calculator
+         data-ev-id="{{ $model.evkx_id }}"
+         data-model-title="{{ $model.title }}"
+         data-api-url="https://evkx.net/api/evs/calculatetravel"
+         data-lang="{{ $page.Language.Lang }}"
+         data-fallback-url="https://evkx.net/{{ if $nb }}nb/{{ end }}evcompare/travelcalculator/?evs={{ $model.evkx_id }}">
+      <form class="range-calculator__form" data-calculator-form>
+        <fieldset class="range-calculator__fieldset">
+          <legend>{{ if $nb }}Tilgjengelig batteri{{ else }}Available battery{{ end }}</legend>
+          <div class="range-calculator__segments" data-range-mode>
+            <label><input type="radio" name="rangeMode" value="100_0" checked><span>100–0%</span></label>
+            <label><input type="radio" name="rangeMode" value="100_10"><span>100–10%</span></label>
+            <label><input type="radio" name="rangeMode" value="80_10"><span>80–10%</span></label>
+          </div>
+        </fieldset>
+
+        <div class="range-calculator__controls">
+          <label class="range-calculator__control">
+            <span><strong>{{ if $nb }}Hastighet{{ else }}Speed{{ end }}</strong><output data-value="speed">120 km/h</output></span>
+            <input type="range" name="speed" min="30" max="160" step="5" value="120">
+          </label>
+          <label class="range-calculator__control">
+            <span><strong>{{ if $nb }}Temperatur{{ else }}Temperature{{ end }}</strong><output data-value="temperature">20 °C</output></span>
+            <input type="range" name="temperature" min="-20" max="40" step="1" value="20">
+          </label>
+          <label class="range-calculator__control">
+            <span><strong>{{ if $nb }}Klimaanlegg{{ else }}Climate use{{ end }}</strong><output data-value="hvac">0.0 kW</output></span>
+            <input type="range" name="hvac" min="0" max="5" step="0.5" value="0">
+          </label>
+          <label class="range-calculator__select">
+            <span>{{ if $nb }}Veiforhold{{ else }}Road condition{{ end }}</span>
+            <select name="condition">
+              <option value="PerfectDry">{{ if $nb }}Tørt{{ else }}Dry{{ end }}</option>
+              <option value="Moist">{{ if $nb }}Fuktig{{ else }}Damp{{ end }}</option>
+              <option value="Wet">{{ if $nb }}Vått{{ else }}Wet{{ end }}</option>
+              <option value="VeryWet">{{ if $nb }}Svært vått{{ else }}Very wet{{ end }}</option>
+              <option value="Snow">{{ if $nb }}Snø{{ else }}Snow{{ end }}</option>
+              <option value="HardSnow">{{ if $nb }}Hardpakket snø{{ else }}Hard-packed snow{{ end }}</option>
+            </select>
+          </label>
+        </div>
+
+        <details class="range-calculator__advanced">
+          <summary>{{ if $nb }}Flere innstillinger{{ else }}More settings{{ end }}</summary>
+          <div class="range-calculator__advanced-grid">
+            <label class="range-calculator__control">
+              <span><strong>{{ if $nb }}Batterihelse{{ else }}Battery health{{ end }}</strong><output data-value="soh">100%</output></span>
+              <input type="range" name="soh" min="60" max="100" step="1" value="100">
+            </label>
+            <label class="range-calculator__select">
+              <span>{{ if $nb }}Utstyrsnivå{{ else }}Trim level{{ end }}</span>
+              <select name="trimLevel">
+                <option value="base">{{ if $nb }}Basis{{ else }}Base{{ end }}</option>
+                <option value="mid">{{ if $nb }}Mellom{{ else }}Mid{{ end }}</option>
+                <option value="top">{{ if $nb }}Topp{{ else }}Top{{ end }}</option>
+              </select>
+            </label>
+            <label class="range-calculator__toggle">
+              <input type="checkbox" name="isTowing">
+              <span>{{ if $nb }}Kjører med tilhenger{{ else }}Towing a trailer{{ end }}</span>
+            </label>
+            <label class="range-calculator__select" data-trailer-control hidden>
+              <span>{{ if $nb }}Tilhengertype{{ else }}Trailer type{{ end }}</span>
+              <select name="trailerKey">
+                <option value="smallflatbed750">{{ if $nb }}Liten planhenger, opptil 750 kg{{ else }}Small flatbed, up to 750 kg{{ end }}</option>
+                <option value="twinaxleflatbed">{{ if $nb }}Tandem planhenger{{ else }}Twin-axle flatbed{{ end }}</option>
+                <option value="smallcaravan">{{ if $nb }}Liten campingvogn{{ else }}Small caravan{{ end }}</option>
+                <option value="largecaravan">{{ if $nb }}Stor campingvogn{{ else }}Large caravan{{ end }}</option>
+              </select>
+            </label>
+          </div>
+        </details>
+
+        <div class="range-calculator__actions">
+          <button class="btn-primary btn-primary--lg" type="submit" data-calculator-submit>{{ if $nb }}Beregn rekkevidde{{ else }}Calculate range{{ end }}</button>
+          <p>{{ if $nb }}Anslaget er modellbasert og kan avvike fra faktisk rekkevidde.{{ else }}This model-based estimate may differ from real-world range.{{ end }}</p>
+        </div>
+      </form>
+
+      <section class="range-calculator__result" aria-live="polite" aria-busy="true" data-calculator-result>
+        <div class="microlabel">{{ if $nb }}Beregnet rekkevidde{{ else }}Estimated range{{ end }}</div>
+        <div class="range-calculator__range"><strong data-result-range>—</strong><span>km</span></div>
+        <p class="range-calculator__vehicle" data-result-vehicle>{{ if $nb }}Beregner for {{ $model.title }}{{ else }}Calculating for {{ $model.title }}{{ end }}</p>
+        <div class="range-calculator__metrics">
+          <div><span>{{ if $nb }}Forbruk{{ else }}Consumption{{ end }}</span><strong data-result-consumption>—</strong></div>
+          <div><span>{{ if $nb }}Tilgjengelig energi{{ else }}Available energy{{ end }}</span><strong data-result-energy>—</strong></div>
+          <div><span>{{ if $nb }}Kjøretid{{ else }}Driving time{{ end }}</span><strong data-result-time>—</strong></div>
+        </div>
+        <div class="range-calculator__breakdown" data-consumption-breakdown hidden>
+          <h3>{{ if $nb }}Energibruk per kilometer{{ else }}Energy use per kilometre{{ end }}</h3>
+          <div data-breakdown-rows></div>
+        </div>
+        <p class="range-calculator__status" data-calculator-status>{{ if $nb }}Beregner…{{ else }}Calculating…{{ end }}</p>
+        <p class="model-calculator__error" data-calculator-error hidden>{{ if $nb }}Kalkulatoren kunne ikke hente et resultat.{{ else }}The calculator could not retrieve a result.{{ end }} <a href="https://evkx.net/{{ if $nb }}nb/{{ end }}evcompare/travelcalculator/?evs={{ $model.evkx_id }}">{{ if $nb }}Åpne kalkulatoren på EVKX.net{{ else }}Open the calculator on EVKX.net{{ end }}</a>.</p>
+      </section>
     </div>
-    <p class="model-calculator__source">{{ if eq $page.Language.Lang "nb" }}Kjøretøydata og beregninger levert av{{ else }}Vehicle data and calculations by{{ end }} <a href="https://evkx.net/{{ if eq $page.Language.Lang "nb" }}nb/{{ end }}evcompare/travelcalculator/?evs={{ $model.evkx_id }}">EVKX.net</a>.</p>
+    <noscript><p class="model-calculator__source">{{ if $nb }}JavaScript må være aktivert for å bruke kalkulatoren.{{ else }}JavaScript is required to use the calculator.{{ end }}</p></noscript>
+    <p class="model-calculator__source">{{ if $nb }}Kjøretøydata og beregningsmotor levert av{{ else }}Vehicle data and calculation engine provided by{{ end }} <a href="https://evkx.net/{{ if $nb }}nb/{{ end }}evcompare/travelcalculator/?evs={{ $model.evkx_id }}">EVKX.net</a>.</p>
   </div>
 </section>
-<script type="module" src="/js/evkx-travel-calculator.js"></script>
+<script type="module" src="{{ "js/evkx-travel-calculator.js" | relURL }}"></script>
 {{ end }}

--- a/static/css/ehga/site.css
+++ b/static/css/ehga/site.css
@@ -125,14 +125,62 @@ button, input, select { font: inherit; }
 .model-hero__description { max-width: 66ch; margin: 0; color: var(--text-on-dark-2); font: var(--body-lede); }
 .model-stats { position: relative; z-index: 2; display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 14px; padding-top: 24px; }
 
-.model-calculator { border-top: 1px solid var(--border-on-dark); }
+.model-calculator { scroll-margin-top: calc(var(--nav-height) + 64px); border-top: 1px solid var(--border-on-dark); }
 .model-calculator__heading { display: grid; grid-template-columns: minmax(0,1.2fr) minmax(280px,.8fr); gap: clamp(24px,5vw,72px); align-items: end; margin-bottom: 30px; }
 .model-calculator__heading .h-section { max-width: 760px; margin-top: 12px; }
 .model-calculator__heading p { max-width: 54ch; margin: 0; color: var(--text-on-dark-2); }
-.model-calculator__surface { min-height: 320px; padding: clamp(18px,3vw,34px); border: 1px solid var(--border-on-dark-strong); border-radius: var(--radius-xl); background: var(--ink-2); }
+.model-calculator__surface { display: grid; grid-template-columns: minmax(0,1.25fr) minmax(300px,.75fr); min-height: 420px; padding: 0; overflow: hidden; border: 1px solid var(--border-on-dark-strong); border-radius: var(--radius-xl); background: var(--ink-2); }
 .model-calculator__loading, .model-calculator__error { margin: 0; color: var(--text-on-dark-2); }
 .model-calculator__error a, .model-calculator__source a { color: var(--accent); }
 .model-calculator__source { margin: 16px 0 0; color: var(--text-on-dark-4); font: var(--body-s); }
+.range-calculator__form { min-width: 0; padding: 32px; }
+.range-calculator__fieldset { margin: 0 0 28px; padding: 0; border: 0; }
+.range-calculator__fieldset legend, .range-calculator__select > span { display: block; margin-bottom: 10px; color: var(--text-on-dark-3); font: var(--microlabel-s); letter-spacing: .1em; text-transform: uppercase; }
+.range-calculator__segments { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); max-width: 470px; padding: 4px; border: 1px solid var(--border-on-dark-strong); border-radius: var(--radius-m); background: var(--ink); }
+.range-calculator__segments label { position: relative; min-width: 0; }
+.range-calculator__segments input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.range-calculator__segments span { display: block; padding: 10px 12px; border-radius: var(--radius-s); color: var(--text-on-dark-3); text-align: center; font: 600 12px/1 var(--font-display); cursor: pointer; }
+.range-calculator__segments input:checked + span { background: var(--accent); color: white; }
+.range-calculator__segments input:focus-visible + span { outline: 2px solid white; outline-offset: 2px; }
+.range-calculator__controls, .range-calculator__advanced-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 24px 28px; }
+.range-calculator__control { min-width: 0; }
+.range-calculator__control > span { display: flex; justify-content: space-between; gap: 16px; margin-bottom: 13px; color: var(--text-on-dark-2); font: var(--body-s); }
+.range-calculator__control strong { color: white; font-weight: 600; }
+.range-calculator__control output { color: var(--accent); font: 600 12px/1.4 var(--font-mono); }
+.range-calculator__control input[type="range"] { width: 100%; height: 3px; margin: 8px 0; appearance: none; border-radius: 2px; outline: 0; background: var(--border-on-dark-strong); accent-color: var(--accent); cursor: pointer; }
+.range-calculator__control input[type="range"]::-webkit-slider-thumb { width: 20px; height: 20px; appearance: none; border: 3px solid var(--ink-2); border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.range-calculator__control input[type="range"]::-moz-range-thumb { width: 14px; height: 14px; border: 3px solid var(--ink-2); border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.range-calculator__control input[type="range"]:focus-visible { box-shadow: 0 0 0 3px rgba(232,89,12,.24); }
+.range-calculator__select select { width: 100%; min-height: 46px; padding: 10px 38px 10px 13px; border: 1px solid var(--border-on-dark-strong); border-radius: var(--radius-s); outline: 0; background: var(--ink); color: white; }
+.range-calculator__select select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(232,89,12,.18); }
+.range-calculator__advanced { margin-top: 28px; padding-top: 22px; border-top: 1px solid var(--border-on-dark); }
+.range-calculator__advanced summary { width: max-content; color: var(--text-on-dark-2); font: 600 12px/1.4 var(--font-display); cursor: pointer; }
+.range-calculator__advanced[open] summary { margin-bottom: 24px; color: white; }
+.range-calculator__toggle { display: flex; min-height: 46px; align-items: center; gap: 12px; color: var(--text-on-dark-2); cursor: pointer; }
+.range-calculator__toggle input { width: 20px; height: 20px; accent-color: var(--accent); }
+.range-calculator__actions { display: flex; align-items: center; gap: 20px; margin-top: 30px; }
+.range-calculator__actions p { max-width: 42ch; margin: 0; color: var(--text-on-dark-4); font: var(--body-s); }
+.range-calculator__actions button:disabled { cursor: wait; opacity: .7; }
+.range-calculator__result { min-width: 0; padding: 32px; border-left: 1px solid var(--border-on-dark); background: rgba(255,255,255,.025); }
+.range-calculator__range { display: flex; align-items: baseline; gap: 10px; margin-top: 18px; color: white; }
+.range-calculator__range strong { font: 800 68px/.9 var(--font-display); }
+.range-calculator__range span { color: var(--text-on-dark-3); font: 600 17px/1 var(--font-display); }
+.range-calculator__vehicle { min-height: 22px; margin: 14px 0 24px; color: var(--text-on-dark-2); font: var(--body-s); }
+.range-calculator__metrics { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 1px; overflow: hidden; border: 1px solid var(--border-on-dark); border-radius: var(--radius-m); background: var(--border-on-dark); }
+.range-calculator__metrics > div { min-width: 0; padding: 13px 11px; background: var(--ink-2); }
+.range-calculator__metrics span { display: block; color: var(--text-on-dark-4); font: 400 9px/1.2 var(--font-mono); letter-spacing: .08em; text-transform: uppercase; }
+.range-calculator__metrics strong { display: block; margin-top: 7px; overflow-wrap: anywhere; color: white; font: 600 12px/1.25 var(--font-display); }
+.range-calculator__breakdown { margin-top: 26px; }
+.range-calculator__breakdown[hidden], .range-calculator__select[hidden], .model-calculator__error[hidden] { display: none; }
+.range-calculator__breakdown h3 { margin: 0 0 14px; color: var(--text-on-dark-3); font: var(--microlabel-s); letter-spacing: .1em; text-transform: uppercase; }
+.range-calculator__breakdown-row + .range-calculator__breakdown-row { margin-top: 11px; }
+.range-calculator__breakdown-row > div:first-child { display: flex; justify-content: space-between; gap: 12px; color: var(--text-on-dark-3); font: 400 10px/1.3 var(--font-mono); }
+.range-calculator__breakdown-row strong { color: var(--text-on-dark-2); font-weight: 500; }
+.range-calculator__breakdown-track { height: 3px; margin-top: 6px; overflow: hidden; border-radius: 2px; background: var(--border-on-dark-strong); }
+.range-calculator__breakdown-track i { display: block; height: 100%; border-radius: inherit; background: var(--accent); }
+.range-calculator__status { margin: 18px 0 0; color: var(--text-on-dark-4); font: var(--body-s); }
+.range-calculator__result .model-calculator__error { margin-top: 12px; }
+.model-calculator__surface.is-loading .range-calculator__result > :not(.range-calculator__status):not(.model-calculator__error) { opacity: .55; }
 
 .prose { width: min(100%, var(--container-prose)); margin: 0 auto; }
 .prose > :first-child { margin-top: 0; }
@@ -229,6 +277,8 @@ button, input, select { font: inherit; }
   .grid-3, .grid-4, .editorial-grid { grid-template-columns: repeat(2,minmax(0,1fr)); }
   .model-stats { grid-template-columns: repeat(2,minmax(0,1fr)); }
   .model-calculator__heading { grid-template-columns: 1fr; align-items: start; }
+  .model-calculator__surface { grid-template-columns: 1fr; }
+  .range-calculator__result { border-top: 1px solid var(--border-on-dark); border-left: 0; }
   .generated-specs__groups { column-count: 2; }
   .compare-slots { grid-template-columns: 1fr; }
   .gallery-grid .photo-tile, .gallery-grid .photo-tile:nth-child(1), .gallery-grid .photo-tile:nth-child(6) { grid-column: span 6; grid-row: span 1; }
@@ -246,6 +296,12 @@ button, input, select { font: inherit; }
   .section-heading { align-items: start; flex-direction: column; }
   .model-hero { min-height: 490px; }
   .model-stats { margin-top: 0; padding-top: 14px; }
+  .range-calculator__form, .range-calculator__result { padding: 22px 18px; }
+  .range-calculator__controls, .range-calculator__advanced-grid { grid-template-columns: 1fr; gap: 22px; }
+  .range-calculator__actions { align-items: stretch; flex-direction: column; }
+  .range-calculator__actions .btn-primary { width: 100%; }
+  .range-calculator__range strong { font-size: 54px; }
+  .range-calculator__metrics { grid-template-columns: 1fr; }
   .model-card__meta { gap: 6px; }
   .site-footer__grid { grid-template-columns: 1fr 1fr; gap: 28px 20px; }
   .site-footer__brand { grid-column: 1/-1; }

--- a/static/js/evkx-travel-calculator.js
+++ b/static/js/evkx-travel-calculator.js
@@ -1,24 +1,188 @@
-const host = document.querySelector('[data-evkx-travel-calculator]');
+const calculators = document.querySelectorAll('[data-ehga-range-calculator]');
 
-if (host) {
-  const assetBase = host.dataset.assetBase || 'https://media.evkx.net/wwwroot/assets/travelcalculator/';
-  const manifestUrl = new URL('manifest.json', assetBase);
+const labels = {
+  en: {
+    loading: 'Calculating…',
+    ready: 'Updated with the selected conditions.',
+    error: 'The calculator could not retrieve a result.',
+    button: 'Calculate range',
+    calculating: 'Calculating…',
+    parts: {
+      aeroWhPerKm: 'Air resistance',
+      rollingWhPerKm: 'Drivetrain and rolling resistance',
+      hvacWhPerKm: 'Climate',
+      auxWhPerKm: 'Auxiliary systems',
+      trailerWhPerKm: 'Trailer',
+    },
+  },
+  nb: {
+    loading: 'Beregner…',
+    ready: 'Oppdatert med valgte forhold.',
+    error: 'Kalkulatoren kunne ikke hente et resultat.',
+    button: 'Beregn rekkevidde',
+    calculating: 'Beregner…',
+    parts: {
+      aeroWhPerKm: 'Luftmotstand',
+      rollingWhPerKm: 'Drivverk og rullemotstand',
+      hvacWhPerKm: 'Klima',
+      auxWhPerKm: 'Hjelpesystemer',
+      trailerWhPerKm: 'Tilhenger',
+    },
+  },
+};
 
-  try {
-    const response = await fetch(manifestUrl, { mode: 'cors' });
-    if (!response.ok) throw new Error(`EVKX manifest returned ${response.status}`);
+const number = (value, digits = 0) => new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: digits,
+  minimumFractionDigits: digits,
+}).format(value);
 
-    const manifest = await response.json();
-    const scriptPath = manifest['index.html']?.file;
-    const cssPath = manifest['style.css']?.file;
-    if (!scriptPath || !cssPath) throw new Error('EVKX calculator assets are missing from the manifest');
-
-    host.dataset.cssHref = new URL(cssPath, assetBase).href;
-    await import(new URL(scriptPath, assetBase).href);
-  } catch (error) {
-    console.error('Unable to load the EVKX range calculator', error);
-    const norwegian = host.dataset.lang === 'nb';
-    const fallbackUrl = `https://evkx.net/${norwegian ? 'nb/' : ''}evcompare/travelcalculator/?evs=${encodeURIComponent(host.dataset.evId || '')}`;
-    host.innerHTML = `<p class="model-calculator__error">${norwegian ? 'Kalkulatoren kunne ikke lastes.' : 'The calculator could not be loaded.'} <a href="${fallbackUrl}">${norwegian ? 'Åpne den på EVKX.net' : 'Open it on EVKX.net'}</a>.</p>`;
-  }
+function duration(value) {
+  if (!value) return '—';
+  const match = String(value).match(/(?:(\d+)\.)?(\d{1,2}):(\d{2})/);
+  if (!match) return String(value);
+  const days = Number(match[1] || 0);
+  const hours = Number(match[2]) + days * 24;
+  const minutes = Number(match[3]);
+  return `${hours} h ${minutes.toString().padStart(2, '0')} min`;
 }
+
+function setLoading(host, loading, copy) {
+  const result = host.querySelector('[data-calculator-result]');
+  const button = host.querySelector('[data-calculator-submit]');
+  const status = host.querySelector('[data-calculator-status]');
+  result.setAttribute('aria-busy', String(loading));
+  button.disabled = loading;
+  button.textContent = loading ? copy.calculating : copy.button;
+  status.textContent = loading ? copy.loading : copy.ready;
+  host.classList.toggle('is-loading', loading);
+}
+
+function updateOutput(form, name, value) {
+  const output = form.querySelector(`[data-value="${name}"]`);
+  if (!output) return;
+  if (name === 'speed') output.textContent = `${value} km/h`;
+  if (name === 'temperature') output.textContent = `${value} °C`;
+  if (name === 'hvac') output.textContent = `${Number(value).toFixed(1)} kW`;
+  if (name === 'soh') output.textContent = `${value}%`;
+}
+
+function renderBreakdown(host, trip, copy) {
+  const wrapper = host.querySelector('[data-consumption-breakdown]');
+  const rows = host.querySelector('[data-breakdown-rows]');
+  const keys = ['aeroWhPerKm', 'rollingWhPerKm', 'hvacWhPerKm', 'auxWhPerKm', 'trailerWhPerKm'];
+  const parts = keys
+    .map((key) => ({ key, value: Number(trip[key] || 0) }))
+    .filter((part) => part.value > 0);
+  const maximum = Math.max(...parts.map((part) => part.value), 1);
+
+  rows.replaceChildren();
+  parts.forEach((part) => {
+    const row = document.createElement('div');
+    row.className = 'range-calculator__breakdown-row';
+
+    const heading = document.createElement('div');
+    const name = document.createElement('span');
+    const value = document.createElement('strong');
+    name.textContent = copy.parts[part.key];
+    value.textContent = `${number(part.value, 0)} Wh/km`;
+    heading.append(name, value);
+
+    const track = document.createElement('div');
+    track.className = 'range-calculator__breakdown-track';
+    const fill = document.createElement('i');
+    fill.style.width = `${Math.max(3, (part.value / maximum) * 100)}%`;
+    track.append(fill);
+    row.append(heading, track);
+    rows.append(row);
+  });
+  wrapper.hidden = parts.length === 0;
+}
+
+function renderResult(host, trip, copy) {
+  let modelName = trip.model || host.dataset.modelTitle || '';
+  if (host.dataset.modelTitle?.startsWith('AUDI ')) {
+    modelName = modelName.replace(/^Audi\s+/i, 'AUDI ').replace(/\be5\b/i, 'E5').replace(/\be7x\b/i, 'E7X');
+  }
+  host.querySelector('[data-result-range]').textContent = number(Number(trip.totalDistance || 0));
+  host.querySelector('[data-result-consumption]').textContent = `${number(Number(trip.whKm || 0), 0)} Wh/km`;
+  host.querySelector('[data-result-energy]').textContent = `${number(Number(trip.totalConsumption || 0), 1)} kWh`;
+  host.querySelector('[data-result-time]').textContent = duration(trip.totalTime);
+  host.querySelector('[data-result-vehicle]').textContent = modelName;
+  renderBreakdown(host, trip, copy);
+}
+
+calculators.forEach((host) => {
+  const form = host.querySelector('[data-calculator-form]');
+  const lang = host.dataset.lang === 'nb' ? 'nb' : 'en';
+  const copy = labels[lang];
+  const error = host.querySelector('[data-calculator-error]');
+  const trailerControl = host.querySelector('[data-trailer-control]');
+  let requestController;
+  let requestNumber = 0;
+
+  form.querySelectorAll('input[type="range"]').forEach((input) => {
+    updateOutput(form, input.name, input.value);
+    input.addEventListener('input', () => updateOutput(form, input.name, input.value));
+  });
+
+  form.elements.isTowing.addEventListener('change', () => {
+    trailerControl.hidden = !form.elements.isTowing.checked;
+  });
+
+  async function calculate() {
+    const currentRequest = ++requestNumber;
+    requestController?.abort();
+    const controller = new AbortController();
+    requestController = controller;
+    const timeout = window.setTimeout(() => controller.abort(), 20000);
+    error.hidden = true;
+    setLoading(host, true, copy);
+
+    const data = new FormData(form);
+    const payload = {
+      eVs: [host.dataset.evId],
+      mode: 'Range',
+      rangeMode: data.get('rangeMode'),
+      travelSpeed: Number(data.get('speed')),
+      temperature: Number(data.get('temperature')),
+      drivingCondition: data.get('condition'),
+      hvacUsage: Number(data.get('hvac')),
+      soh: Number(data.get('soh')),
+      heatLossFactor: 0,
+      useImperialUnits: false,
+      trimLevel: data.get('trimLevel'),
+      ...(data.get('isTowing') ? { trailerKey: data.get('trailerKey') } : {}),
+    };
+
+    try {
+      const response = await fetch(host.dataset.apiUrl, {
+        method: 'POST',
+        mode: 'cors',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error(`EVKX calculator returned ${response.status}`);
+      const result = await response.json();
+      const trip = result.calculatedTrips?.[0];
+      if (!trip) throw new Error('EVKX calculator returned no trip');
+      renderResult(host, trip, copy);
+      setLoading(host, false, copy);
+    } catch (reason) {
+      if (currentRequest !== requestNumber) return;
+      console.error('Unable to calculate range with EVKX', reason);
+      setLoading(host, false, copy);
+      host.querySelector('[data-calculator-status]').textContent = copy.error;
+      error.hidden = false;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    calculate();
+  });
+
+  calculate();
+});


### PR DESCRIPTION
## Summary
- replace the remotely loaded EVKX calculator bundle with a dependency-free JavaScript application hosted by EHGA
- add bilingual EHGA controls for charge window, speed, temperature, climate use, road conditions, battery health, trim and towing
- render range, consumption, available energy, driving time and the consumption breakdown using the EVKX calculation API
- add loading, timeout, error and EVKX fallback states plus responsive desktop/mobile styling
- correct the Q6 calculator mapping to Q6 e-tron performance and E7X to the 109.3 kWh Pioneer Long-Range record

## Verification
- 
ode --check static/js/evkx-travel-calculator.js
- hugo --minify --enableGitInfo=false
- git diff --check
- verified live EVKX API CORS from localhost and successful recalculation after changing speed, road condition and charge window
- visually checked desktop (1440 px) and mobile (390 px) layouts with no horizontal overflow
- verified English and Norwegian UI and E7X result branding