### PR TITLE
Fix calculator caching and add variant selection

### DIFF
--- a/assets/js/evkx-travel-calculator.js
+++ b/assets/js/evkx-travel-calculator.js
@@ -36,6 +36,49 @@ const number = (value, digits = 0) => new Intl.NumberFormat(undefined, {
   minimumFractionDigits: digits,
 }).format(value);
 
+function formatModelName(host, value) {
+  let modelName = value || host.dataset.modelTitle || '';
+  if (host.dataset.modelTitle?.startsWith('AUDI ')) {
+    modelName = modelName.replace(/^Audi\s+/i, 'AUDI ').replace(/\be5\b/i, 'E5').replace(/\be7x\b/i, 'E7X');
+  }
+  return modelName;
+}
+
+function belongsToModelFamily(family, value) {
+  const name = String(value || '').toLowerCase();
+  const patterns = {
+    'q4-e-tron': /^audi q4\b/,
+    'q5-e-tron': /^audi q5\b/,
+    'q6-e-tron': /^audi (?:q6l?|sq6)\b/,
+    'q8-e-tron': /^audi (?:q8|sq8)\b/,
+    'e-tron-gt': /e-tron gt/,
+    'a6-e-tron': /^audi (?:a6|s6)\b/,
+    'e-tron': /^audi e-tron(?:\s|$)/,
+    'e5': /^audi e5\b/,
+    'e7x': /^audi e7x\b/,
+  };
+  return patterns[family]?.test(name) ?? true;
+}
+
+function isCalculableVariant(variant) {
+  return !Array.isArray(variant.battery)
+    || variant.battery.length === 0
+    || variant.battery.some((battery) => Number(battery.netCapacity) > 0);
+}
+
+function variantLabel(host, variant) {
+  const battery = variant.battery?.[0]?.grossCapacity;
+  const years = Array.isArray(variant.modelYear)
+    ? variant.modelYear.map((year) => /^\d{4}$/.test(String(year)) ? `MY${year}` : String(year).toUpperCase()).join(', ')
+    : '';
+  return [
+    formatModelName(host, variant.name),
+    Number.isFinite(Number(battery)) && Number(battery) > 0 ? `${number(Number(battery), Number.isInteger(Number(battery)) ? 0 : 1)} kWh` : '',
+    years,
+    isCalculableVariant(variant) ? '' : (host.dataset.lang === 'nb' ? 'rekkeviddedata mangler' : 'range data unavailable'),
+  ].filter(Boolean).join(' · ');
+}
+
 function duration(value) {
   if (!value) return '—';
   const match = String(value).match(/(?:(\d+)\.)?(\d{1,2}):(\d{2})/);
@@ -99,10 +142,7 @@ function renderBreakdown(host, trip, copy) {
 }
 
 function renderResult(host, trip, copy) {
-  let modelName = trip.model || host.dataset.modelTitle || '';
-  if (host.dataset.modelTitle?.startsWith('AUDI ')) {
-    modelName = modelName.replace(/^Audi\s+/i, 'AUDI ').replace(/\be5\b/i, 'E5').replace(/\be7x\b/i, 'E7X');
-  }
+  const modelName = formatModelName(host, trip.model);
   host.querySelector('[data-result-range]').textContent = number(Number(trip.totalDistance || 0));
   host.querySelector('[data-result-consumption]').textContent = `${number(Number(trip.whKm || 0), 0)} Wh/km`;
   host.querySelector('[data-result-energy]').textContent = `${number(Number(trip.totalConsumption || 0), 1)} kWh`;
@@ -117,6 +157,7 @@ calculators.forEach((host) => {
   const copy = labels[lang];
   const error = host.querySelector('[data-calculator-error]');
   const trailerControl = host.querySelector('[data-trailer-control]');
+  const variantSelect = host.querySelector('[data-variant-select]');
   let requestController;
   let requestNumber = 0;
 
@@ -129,6 +170,56 @@ calculators.forEach((host) => {
     trailerControl.hidden = !form.elements.isTowing.checked;
   });
 
+  async function loadVariants() {
+    try {
+      const response = await fetch(host.dataset.searchUrl, {
+        method: 'POST',
+        mode: 'cors',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: host.dataset.modelQuery,
+          brands: ['Audi'],
+          page: 1,
+          pageSize: 50,
+          includeDiscontinued: true,
+        }),
+      });
+      if (!response.ok) throw new Error(`EVKX search returned ${response.status}`);
+      const result = await response.json();
+      const seen = new Set();
+      const variants = (result.evs || [])
+        .filter((variant) => belongsToModelFamily(host.dataset.modelFamily, variant.name))
+        .filter((variant) => variant.evId && !seen.has(variant.evId) && seen.add(variant.evId));
+      if (!variants.length) return;
+
+      const defaultId = host.dataset.evId.toLowerCase();
+      let selectedId = host.dataset.evId;
+      const options = variants.map((variant) => {
+        const option = document.createElement('option');
+        option.value = variant.evId;
+        option.textContent = variantLabel(host, variant);
+        option.disabled = !isCalculableVariant(variant);
+        if (defaultId === variant.evId.toLowerCase() || defaultId.endsWith(variant.evId.toLowerCase())) {
+          selectedId = variant.evId;
+        }
+        return option;
+      });
+
+      if (selectedId === host.dataset.evId) {
+        const fallback = document.createElement('option');
+        fallback.value = host.dataset.evId;
+        fallback.textContent = host.dataset.modelTitle;
+        options.unshift(fallback);
+      }
+      variantSelect.replaceChildren(...options);
+      variantSelect.value = selectedId;
+    } catch (reason) {
+      console.warn('Unable to load EVKX variants', reason);
+    } finally {
+      variantSelect.disabled = false;
+    }
+  }
+
   async function calculate() {
     const currentRequest = ++requestNumber;
     requestController?.abort();
@@ -140,7 +231,7 @@ calculators.forEach((host) => {
 
     const data = new FormData(form);
     const payload = {
-      eVs: [host.dataset.evId],
+      eVs: [data.get('vehicleId') || host.dataset.evId],
       mode: 'Range',
       rangeMode: data.get('rangeMode'),
       travelSpeed: Number(data.get('speed')),
@@ -184,5 +275,7 @@ calculators.forEach((host) => {
     calculate();
   });
 
+  variantSelect.addEventListener('change', calculate);
+  loadVariants();
   calculate();
 });

--- a/layouts/partials/range-calculator.html
+++ b/layouts/partials/range-calculator.html
@@ -16,10 +16,20 @@
          data-ehga-range-calculator
          data-ev-id="{{ $model.evkx_id }}"
          data-model-title="{{ $model.title }}"
+         data-model-family="{{ $model.slug }}"
+         data-model-query="{{ $model.title }}"
          data-api-url="https://evkx.net/api/evs/calculatetravel"
+         data-search-url="https://evkx.net/api/evs/search"
          data-lang="{{ $page.Language.Lang }}"
          data-fallback-url="https://evkx.net/{{ if $nb }}nb/{{ end }}evcompare/travelcalculator/?evs={{ $model.evkx_id }}">
       <form class="range-calculator__form" data-calculator-form>
+        <label class="range-calculator__select range-calculator__variant">
+          <span>{{ if $nb }}Variant{{ else }}Variant{{ end }}</span>
+          <select name="vehicleId" data-variant-select disabled>
+            <option value="{{ $model.evkx_id }}">{{ $model.title }}</option>
+          </select>
+        </label>
+
         <fieldset class="range-calculator__fieldset">
           <legend>{{ if $nb }}Tilgjengelig batteri{{ else }}Available battery{{ end }}</legend>
           <div class="range-calculator__segments" data-range-mode>
@@ -113,5 +123,6 @@
     <p class="model-calculator__source">{{ if $nb }}Kjøretøydata og beregningsmotor levert av{{ else }}Vehicle data and calculation engine provided by{{ end }} <a href="https://evkx.net/{{ if $nb }}nb/{{ end }}evcompare/travelcalculator/?evs={{ $model.evkx_id }}">EVKX.net</a>.</p>
   </div>
 </section>
-<script type="module" src="{{ "js/evkx-travel-calculator.js" | relURL }}"></script>
+{{ $calculatorScript := resources.Get "js/evkx-travel-calculator.js" | fingerprint }}
+<script type="module" src="{{ $calculatorScript.RelPermalink }}" integrity="{{ $calculatorScript.Data.Integrity }}"></script>
 {{ end }}

--- a/static/css/ehga/site.css
+++ b/static/css/ehga/site.css
@@ -134,6 +134,7 @@ button, input, select { font: inherit; }
 .model-calculator__error a, .model-calculator__source a { color: var(--accent); }
 .model-calculator__source { margin: 16px 0 0; color: var(--text-on-dark-4); font: var(--body-s); }
 .range-calculator__form { min-width: 0; padding: 32px; }
+.range-calculator__variant { max-width: 680px; margin-bottom: 28px; }
 .range-calculator__fieldset { margin: 0 0 28px; padding: 0; border: 0; }
 .range-calculator__fieldset legend, .range-calculator__select > span { display: block; margin-bottom: 10px; color: var(--text-on-dark-3); font: var(--microlabel-s); letter-spacing: .1em; text-transform: uppercase; }
 .range-calculator__segments { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); max-width: 470px; padding: 4px; border: 1px solid var(--border-on-dark-strong); border-radius: var(--radius-m); background: var(--ink); }


### PR DESCRIPTION
## Summary
- move the calculator module into Hugo Pipes and fingerprint it so iPad/Safari cannot reuse the incompatible pre-redesign script URL
- load model-family variants from the EVKX search API and keep the configured representative variant selected by default
- label variants with gross battery capacity and normalized model year
- recalculate immediately when the selected variant changes
- keep EVKX variants with missing usable-battery data visible but disabled instead of returning a misleading zero range

## Verification
- confirmed the previous production asset was cached with max-age=600
- 
ode --check assets/js/evkx-travel-calculator.js
- hugo --minify --enableGitInfo=false
- verified Hugo emits a hashed module filename with an integrity attribute and no unhashed calculator asset
- verified all 11 Q6-family variants load, with Q6 e-tron performance 100 kWh MY2024 selected by default
- switched to Q6 e-tron 83 kWh MY2025 and confirmed the EVKX result changed to 342 km / 75.8 kWh
- verified five E7X variants are listed and records without usable range data are disabled
- checked the calculator at an iPad portrait viewport with no horizontal overflow