### PR TITLE
Fix homepage technology links

### DIFF
--- a/content/technology/motors/_index.de.md
+++ b/content/technology/motors/_index.de.md
@@ -1,0 +1,41 @@
+---
+title: Elektromotoren
+linktitle: Motoren
+description: Funktionsweise von Permanentmagnet- und Asynchronmotoren und ihre Kombination in elektrischen Audi Antrieben.
+weight: 3
+translation_status: manual
+---
+
+Elektroautos wandeln die Energie der Hochvoltbatterie über einen oder mehrere Elektromotoren in Bewegung um. Beim Verzögern kann der Motor den Energiefluss umkehren und durch Rekuperation elektrische Energie in die Batterie zurückspeisen.
+
+## Permanentmagnet-Synchronmotoren
+
+Ein Permanentmagnet-Synchronmotor (PSM) verwendet Permanentmagnete im Rotor. Dessen Magnetfeld folgt dem rotierenden Feld des Stators. Das ermöglicht eine präzise Regelung, eine hohe Leistungsdichte und einen guten Wirkungsgrad über einen großen Betriebsbereich.
+
+Audi nutzt bei neueren Elektroplattformen häufig einen PSM als Hauptmotor an der Hinterachse. Da dieser Motor den größten Teil des alltäglichen Fahrbetriebs übernimmt, beeinflusst sein Wirkungsgrad Verbrauch und Reichweite unmittelbar.
+
+## Asynchronmotoren
+
+Ein Asynchronmotor (ASM), auch Induktionsmotor genannt, erzeugt das Magnetfeld des Rotors elektrisch und benötigt keine Permanentmagnete. Wird kein Drehmoment angefordert, kann er mit geringen Schleppverlusten inaktiv bleiben. Dadurch eignet er sich als zusätzlicher Motor für einen Allradantrieb.
+
+Bei den quattro-Versionen von Q4 e-tron, Q6 e-tron und A6 e-tron kann ein ASM an der Vorderachse schnell zugeschaltet werden, wenn mehr Traktion oder Leistung benötigt wird. Beim effizienten Fahren bleibt der hintere PSM der Hauptantrieb.
+
+## Leistungselektronik und Getriebe
+
+Die Batterie liefert Gleichstrom, während der Antriebsmotor mit geregeltem Wechselstrom arbeitet. Ein Wechselrichter wandelt und steuert die Energie mehrmals pro Sekunde anhand von Fahrpedalstellung, Geschwindigkeit, verfügbarer Traktion und thermischen Grenzen.
+
+Die elektrischen Antriebseinheiten von Audi vereinen in der Regel Motor, Wechselrichter und ein einstufiges Untersetzungsgetriebe. Ein Elektromotor stellt bereits aus dem Stand nutzbares Drehmoment und einen breiten Drehzahlbereich bereit, sodass normalerweise kein Mehrganggetriebe erforderlich ist. Der e-tron GT bildet eine Ausnahme: Sein Zweiganggetriebe an der Hinterachse verbindet starke Beschleunigung mit Effizienz bei hohem Tempo.
+
+## Rekuperation
+
+Bei der Rekuperation arbeitet der Motor als Generator. Bewegungsenergie wird wieder in elektrische Energie umgewandelt, statt vollständig als Wärme in den Reibungsbremsen verloren zu gehen. Die mögliche Rekuperationsleistung hängt unter anderem von Batterietemperatur, Ladezustand, Traktion und gewähltem Fahrmodus ab.
+
+Audi stimmt die regenerative und hydraulische Bremsung so aufeinander ab, dass die angeforderte Verzögerung vorhersehbar bleibt. Bei einer starken Bremsung oder einer vollständig geladenen Batterie müssen die konventionellen Bremsen einen größeren Anteil übernehmen.
+
+## Unterschiedliche Motorkonzepte
+
+- **Ein Motor mit Hinterradantrieb:** optimiert Effizienz, Reichweite und Gewicht.
+- **Zwei Motoren mit quattro:** ergänzt einen Frontmotor für mehr Traktion und Systemleistung.
+- **Performance-Antriebe:** können zwei permanent erregte Motoren oder, wie beim e-tron S, drei Motoren für eine präzisere Momentverteilung verwenden.
+
+Weitere Details stehen in den modellspezifischen Motorkapiteln zum [Q6 e-tron](../../models/q6-e-tron/drivetrain/motor/) und [A6 e-tron](../../models/a6-e-tron/drivetrain/motor/) sowie in der Übersicht der [Elektroplattformen](../bev-platforms/).

--- a/content/technology/motors/_index.md
+++ b/content/technology/motors/_index.md
@@ -1,0 +1,40 @@
+---
+title: Electric motors
+linktitle: Motors
+description: How permanent-magnet and asynchronous motors work, and why Audi combines them in different electric drivetrains.
+weight: 3
+---
+
+Electric cars convert energy from the high-voltage battery into motion through one or more electric motors. The motor can also reverse this energy flow during deceleration and return electricity to the battery through regenerative braking.
+
+## Permanent-magnet synchronous motors
+
+A permanent-magnet synchronous motor (PSM) uses permanent magnets in the rotor. Its magnetic field follows the rotating field created by the stator, which gives precise control, high power density and strong efficiency across much of the operating range.
+
+Audi commonly uses a PSM as the main rear motor in newer electric platforms. Because this motor handles most everyday driving, its efficiency has a direct effect on consumption and range.
+
+## Asynchronous motors
+
+An asynchronous motor (ASM), also called an induction motor, creates the rotor's magnetic field electrically instead of using permanent magnets. It can be inactive with little drag when no torque is required, making it useful as a secondary motor in an all-wheel-drive system.
+
+On quattro versions of the Q4 e-tron, Q6 e-tron and A6 e-tron, an ASM at the front can engage quickly when the car needs more traction or power. The rear PSM remains the primary drive unit during efficient cruising.
+
+## Inverter and transmission
+
+The battery supplies direct current, while the traction motor operates with controlled alternating current. A power-electronics inverter converts and regulates that energy many times per second according to accelerator position, vehicle speed, available grip and thermal limits.
+
+Audi's electric drive units normally combine the motor, inverter and a single-speed reduction gear. An electric motor delivers useful torque from standstill and across a wide speed range, so a multi-speed gearbox is usually unnecessary. The e-tron GT is an exception, using a two-speed transmission on the rear axle to combine launch performance with high-speed efficiency.
+
+## Regenerative braking
+
+During regeneration, the motor works as a generator. The vehicle's kinetic energy is converted back into electrical energy instead of being dissipated entirely as heat in the friction brakes. The achievable regeneration level depends on battery temperature, state of charge, grip and the selected driving mode.
+
+Audi blends regenerative and hydraulic braking so the requested deceleration remains predictable. Strong braking or a full battery requires a larger contribution from the conventional brakes.
+
+## Different motor layouts
+
+- **Single-motor rear-wheel drive:** prioritizes efficiency, range and lower weight.
+- **Dual-motor quattro:** adds a front motor for traction and higher system output.
+- **Performance layouts:** may use two permanently excited motors or, in models such as the e-tron S, three motors for more precise torque distribution.
+
+See the model-specific motor chapters for the [Q6 e-tron](../../models/q6-e-tron/drivetrain/motor/) and [A6 e-tron](../../models/a6-e-tron/drivetrain/motor/), or read about the underlying [electric vehicle platforms](../bev-platforms/).

--- a/content/technology/motors/_index.nb.md
+++ b/content/technology/motors/_index.nb.md
@@ -1,0 +1,40 @@
+---
+title: Elektriske motorer
+linktitle: Motorer
+description: Slik fungerer permanentmagnet- og asynkronmotorer, og derfor kombinerer Audi dem i forskjellige elektriske drivlinjer.
+weight: 3
+---
+
+Elbiler omdanner energi fra høyvoltbatteriet til bevegelse gjennom én eller flere elektriske motorer. Motoren kan også snu energiflyten under fartsreduksjon og sende strøm tilbake til batteriet gjennom regenerativ bremsing.
+
+## Permanentmagnet-synkronmotorer
+
+En permanentmagnet-synkronmotor (PSM) bruker permanente magneter i rotoren. Magnetfeltet følger det roterende feltet som skapes av statoren. Det gir presis styring, høy effekttetthet og god virkningsgrad over en stor del av arbeidsområdet.
+
+Audi bruker ofte en PSM som hovedmotor på bakakselen i nyere elbilplattformer. Siden denne motoren står for det meste av den daglige kjøringen, påvirker virkningsgraden både forbruk og rekkevidde direkte.
+
+## Asynkronmotorer
+
+En asynkronmotor (ASM), også kalt induksjonsmotor, skaper rotorens magnetfelt elektrisk i stedet for å bruke permanente magneter. Den kan være inaktiv med liten motstand når det ikke trengs dreiemoment, og passer derfor godt som sekundær motor i et firehjulsdriftsystem.
+
+På quattro-versjonene av Q4 e-tron, Q6 e-tron og A6 e-tron kan en ASM foran kobles inn raskt når bilen trenger mer grep eller effekt. Den bakre PSM-en er fortsatt den primære motoren under effektiv kjøring.
+
+## Effektelektronikk og gir
+
+Batteriet leverer likestrøm, mens drivmotoren arbeider med kontrollert vekselstrøm. En vekselretter omformer og regulerer energien mange ganger per sekund ut fra gasspedalstilling, hastighet, tilgjengelig veigrep og temperaturgrenser.
+
+Audis elektriske drivenheter kombinerer vanligvis motor, vekselretter og et ett-trinns reduksjonsgir. En elektromotor leverer nyttig dreiemoment fra stillestående og gjennom et bredt turtallsområde, slik at en flertrinnsgirkasse normalt er unødvendig. e-tron GT er et unntak og bruker et totrinnsgir på bakakselen for å kombinere akselerasjon med effektivitet i høy hastighet.
+
+## Regenerativ bremsing
+
+Under regenerering arbeider motoren som en generator. Bilens bevegelsesenergi omdannes til elektrisk energi i stedet for at alt blir til varme i friksjonsbremsene. Hvor mye bilen kan regenerere, avhenger blant annet av batteritemperatur, ladenivå, veigrep og valgt kjøremodus.
+
+Audi blander regenerativ og hydraulisk bremsing slik at den ønskede retardasjonen oppleves forutsigbar. Ved kraftig bremsing eller fullt batteri må de vanlige bremsene bidra mer.
+
+## Forskjellige motoroppsett
+
+- **Én motor og bakhjulsdrift:** prioriterer effektivitet, rekkevidde og lavere vekt.
+- **To motorer og quattro:** legger til en frontmotor for bedre grep og høyere systemeffekt.
+- **Ytelsesoppsett:** kan bruke to permanentmagnetmotorer eller, som i e-tron S, tre motorer for mer presis momentfordeling.
+
+Se de modellspesifikke motorkapitlene for [Q6 e-tron](../../models/q6-e-tron/drivetrain/motor/) og [A6 e-tron](../../models/a6-e-tron/drivetrain/motor/), eller les om de underliggende [elbilplattformene](../bev-platforms/).

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -43,8 +43,8 @@
   <div class="container">
     <div class="section-heading"><div><div class="microlabel">{{ T "home-understand-technology" }}</div><h2 class="h-section">{{ T "home-technology-heading" }}</h2></div></div>
     <div class="grid-4">
-      {{ $tech := slice (dict "slug" "battery" "title" "home-tech-battery-title" "text" "home-tech-battery-text") (dict "slug" "bev-platforms" "title" "home-tech-platforms-title" "text" "home-tech-platforms-text") (dict "slug" "motors" "title" "home-tech-motors-title" "text" "home-tech-motors-text") (dict "slug" "charging" "title" "home-tech-charging-title" "text" "home-tech-charging-text") }}
-      {{ range $tech }}{{ $p := $.Site.GetPage (printf "/technology/%s/" .slug) }}<article class="card card--interactive"><div class="card__body"><div class="microlabel">{{ T "menu-technology" }}</div><h3 class="card__title" style="margin-top:12px"><a href="{{ with $p }}{{ .RelPermalink }}{{ else }}{{ printf "/technology/%s/" .slug | relLangURL }}{{ end }}">{{ T .title }}</a></h3><p style="color:var(--text-on-light-3);margin-bottom:0">{{ T .text }}</p></div></article>{{ end }}
+      {{ $tech := slice (dict "page" "/technology/battery/" "title" "home-tech-battery-title" "text" "home-tech-battery-text") (dict "page" "/technology/bev-platforms/" "title" "home-tech-platforms-title" "text" "home-tech-platforms-text") (dict "page" "/technology/motors/" "title" "home-tech-motors-title" "text" "home-tech-motors-text") (dict "page" "/technology/battery/charging/" "title" "home-tech-charging-title" "text" "home-tech-charging-text") }}
+      {{ range $tech }}{{ $p := $.Site.GetPage .page }}<article class="card card--interactive"><div class="card__body"><div class="microlabel">{{ T "menu-technology" }}</div><h3 class="card__title" style="margin-top:12px"><a href="{{ with $p }}{{ .RelPermalink }}{{ else }}{{ .page | relLangURL }}{{ end }}">{{ T .title }}</a></h3><p style="color:var(--text-on-light-3);margin-bottom:0">{{ T .text }}</p></div></article>{{ end }}
     </div>
   </div>
 </section>

--- a/tools/audit-content.mjs
+++ b/tools/audit-content.mjs
@@ -258,7 +258,9 @@ function anchorsFor(file) {
   if (anchorCache.has(file)) return anchorCache.get(file);
   const html = fs.readFileSync(file, 'utf8');
   const anchors = new Set();
-  for (const match of html.matchAll(/\s(?:id|name)=["']([^"']+)["']/gi)) anchors.add(match[1]);
+  for (const match of html.matchAll(/\s(?:id|name)=(?:"([^"]+)"|'([^']+)'|([^\s>]+))/gi)) {
+    anchors.add(match[1] || match[2] || match[3]);
+  }
   anchorCache.set(file, anchors);
   return anchors;
 }
@@ -266,8 +268,13 @@ function anchorsFor(file) {
 for (const file of htmlFiles) {
   const html = fs.readFileSync(file, 'utf8');
   const sourceUrl = pageUrlForHtml(file);
-  for (const match of html.matchAll(/\shref=["']([^"']+)["']/gi)) {
-    const href = match[1].trim();
+  const isHomepage = sourceUrl === '/' || /^\/(?:nb|de)\/$/.test(sourceUrl);
+  const hrefPattern = isHomepage
+    ? /\shref=(?:"([^"]+)"|'([^']+)'|([^\s>]+))/gi
+    : /\shref=["']([^"']+)["']/gi;
+
+  for (const match of html.matchAll(hrefPattern)) {
+    const href = (match[1] || match[2] || match[3]).trim();
     if (!href || href.startsWith('mailto:') || href.startsWith('tel:') || href.startsWith('javascript:')) continue;
     let url;
     try {


### PR DESCRIPTION
## Summary
- point the charging card to the existing battery charging article
- add the promised electric-motor article in English, Norwegian and German
- make homepage technology targets explicit instead of relying on generated fallback paths
- extend the content audit to validate minified homepage links and anchors

## Verification
- Hugo build: EN 566 / NB 565 / DE 566 pages
- content audit: 0 findings
- motor and charging destinations verified for all three languages