### PR TITLE
Update Audi A4 e-tron SSP information

### DIFF
--- a/content/models/_index.md
+++ b/content/models/_index.md
@@ -182,14 +182,14 @@ View Legacy Details
 <div class="p-6 h-full flex flex-col justify-center">
 <h3 class="text-xl font-bold text-gray-900 mb-3">Audi A4 e-tron</h3>
 <p class="text-gray-600 text-sm mb-4 leading-relaxed">
-Compact executive electric sedan expected to launch in 2028. Details still unconfirmed.
+Electric compact executive model confirmed for the SSP platform and expected to launch in 2028.
 </p>
 <div class="flex flex-wrap gap-2 mb-4">
-<span class="bg-orange-100 text-orange-800 text-xs font-semibold px-3 py-1 rounded-full">Unconfirmed</span>
+<span class="bg-teal-100 text-teal-800 text-xs font-semibold px-3 py-1 rounded-full">In development</span>
 <span class="bg-gray-100 text-gray-700 text-xs font-semibold px-3 py-1 rounded-full">2028 Expected</span>
 </div>
 <a href="a4-e-tron/" class="block w-full bg-orange-500 hover:bg-orange-600 text-white font-medium py-3 px-4 rounded-lg text-center transition-colors duration-200" style="color: white !important;">
-View Rumors
+Explore Details
 </a>
 </div>
 </div>

--- a/content/models/_index.nb.md
+++ b/content/models/_index.nb.md
@@ -103,7 +103,7 @@ Utforsk detaljer
 <div class="p-6">
 <h3 class="text-xl font-bold text-gray-900 mb-3">Audi A4 e-tron</h3>
 <p class="text-gray-600 text-sm mb-4 leading-relaxed">
-Elektrisk sedan i mellomklassen som erstatter ICE A4. Basert på PPE-plattformen.
+Helelektrisk mellomklassemodell på SSP-plattformen. Audi har bekreftet utviklingen, med lansering ventet i 2028.
 </p>
 <div class="flex flex-wrap gap-2 mb-4">
 <span class="bg-teal-100 text-teal-800 text-xs font-semibold px-3 py-1 rounded-full">Mellomklasse</span>

--- a/content/models/a4-e-tron/_index.de.md
+++ b/content/models/a4-e-tron/_index.de.md
@@ -1,11 +1,17 @@
 ---
 title: "Audi A4 e-tron"
 linktitle: "Audi A4 e-tron"
-description: "Der Audi A4 e-tron ist noch nicht offiziell bestätigt."
+description: "Der Audi A4 e-tron wird für die SSP-Plattform entwickelt und für 2028 erwartet."
 weight: 6
 translation_status: manual
 ---
 
-Audi hat dieses Modell bislang nicht offiziell bestätigt. Es wird voraussichtlich auf der [Premium Platform Electric (PPE)](/de/technology/bev-platforms/ppe/) basieren. Angaben zu Termin, Karosserievarianten und Technik sind noch nicht verlässlich bekannt.
+Audi hat die Entwicklung eines vollelektrischen A4 bestätigt. Vorstandsvorsitzender Gernot Döllner bestätigte im Oktober 2025, dass das Modell die kommende [SSP-Plattform](/de/technology/bev-platforms/ssp/) des Volkswagen-Konzerns nutzen wird – nicht PPE.
+
+Im Juni 2026 erklärte Audi-Technikvorstand Rouven Mohr, es gebe keinen Anlass, den zuvor genannten Marktstart im Jahr 2028 zu korrigieren. Er bestätigte außerdem, dass Audi den A4 e-tron nach der schnelleren „Project House“-Methode entwickelt. Das Fahrzeug soll zu den ersten Audi-Volumenmodellen mit der Designsprache „Radical Next“ gehören. Mohr beschrieb zudem ein neues Innenraumkonzept, mehr physische Bedienelemente und neueste Technik.
+
+[GoAuto berichtet](https://www.goauto.com.au/amp/audi/a4/e-tron/audi-a4-e-tron-confirmed-first-details-emerge/2026-06-29/99667.html) unter Berufung auf eigene Quellen, dass der A4 e-tron als erster Audi das volle Potenzial der SSP-Plattform nutzen soll, einschließlich einer einheitlichen Batteriearchitektur und zonaler Elektronik. Audi hat bislang weder Batteriekapazität und Reichweite noch Ladeleistung oder Motorleistung veröffentlicht. Mohr sprach sich für einen Avant aus; offiziell bestätigt ist diese Karosserievariante jedoch noch nicht.
+
+Quellen: [GoAuto, 29. Juni 2026](https://www.goauto.com.au/amp/audi/a4/e-tron/audi-a4-e-tron-confirmed-first-details-emerge/2026-06-29/99667.html), [Autocar, 7. Oktober 2025](https://www.autocar.co.uk/car-news/new-cars/new-audi-a4-bring-next-gen-tech-and-tt-inspired-look) und [electrive, 6. Juli 2026](https://www.electrive.net/2026/07/06/audi-manager-bestaetigt-a4-e-tron-fuer-2028-auf-neuer-ssp-plattform/).
 
 {{<children description="true" />}}

--- a/content/models/a4-e-tron/_index.md
+++ b/content/models/a4-e-tron/_index.md
@@ -1,10 +1,16 @@
 ---
-title: Audi a4 e-tron
+title: Audi A4 e-tron
 linktitle: Audi A4 e-tron
-description: Audi A4 e-tron will have a world premiere in 2026
+description: Audi A4 e-tron is being developed for the SSP platform and is expected in 2028
 weight: 6
 ---
 
-This model is not official confirmed from Audi. It will be built on the [PPE platform](/technology/bev-platforms/ppe/).
+Audi has confirmed that an all-electric A4 is in development. CEO Gernot Döllner confirmed in October 2025 that the model will use the Volkswagen Group's upcoming [SSP platform](/technology/bev-platforms/ssp/), rather than PPE.
+
+In June 2026, Audi CTO Rouven Mohr said there was no need to correct the previously reported 2028 launch timing. He also confirmed that Audi is developing the A4 e-tron using its faster “Project House” method and that it will be among the first volume-production Audi models to adopt the “Radical Next” design language. Mohr also described a new interior concept, more physical controls and the latest technology.
+
+[GoAuto reports](https://www.goauto.com.au/amp/audi/a4/e-tron/audi-a4-e-tron-confirmed-first-details-emerge/2026-06-29/99667.html), citing its own sources, that the A4 e-tron will be the first Audi to use the full SSP package, including a unified battery architecture and zonal electronics. Audi has not yet announced battery capacity, range, charging power or motor outputs. Mohr supports continuing with an Avant, but the estate body style has not been formally confirmed.
+
+Sources: [GoAuto, 29 June 2026](https://www.goauto.com.au/amp/audi/a4/e-tron/audi-a4-e-tron-confirmed-first-details-emerge/2026-06-29/99667.html) and [Autocar, 7 October 2025](https://www.autocar.co.uk/car-news/new-cars/new-audi-a4-bring-next-gen-tech-and-tt-inspired-look).
 
 {{<children description="true" />}}

--- a/content/models/a4-e-tron/_index.nb.md
+++ b/content/models/a4-e-tron/_index.nb.md
@@ -1,10 +1,16 @@
 ---
-title: Audi a4 e-tron
+title: Audi A4 e-tron
 linktitle: Audi A4 e-tron
-description: Audi A4 e-tron får verdenspremiere i 2026
+description: Audi A4 e-tron utvikles for SSP-plattformen og ventes i 2028
 weight: 6
 ---
 
-Denne modellen er ikke offisielt bekreftet fra Audi. Den vil bygges på [PPE-plattformen](/technology/bev-platforms/ppe/).
+Audi har bekreftet at en helelektrisk A4 er under utvikling. Konsernsjef Gernot Döllner bekreftet i oktober 2025 at modellen skal bruke Volkswagen-konsernets kommende [SSP-plattform](/technology/bev-platforms/ssp/), ikke PPE.
+
+I juni 2026 sa Audis tekniske direktør Rouven Mohr at det ikke var behov for å korrigere den tidligere omtalte lanseringen i 2028. Han bekreftet samtidig at Audi arbeider med A4 e-tron etter selskapets raskere «Project House»-metode, og at bilen blir blant de første volumproduserte Audi-modellene med designspråket «Radical Next». Mohr beskrev også et nytt interiørkonsept, mer fysiske betjeningselementer og den nyeste teknologien.
+
+[GoAuto rapporterer](https://www.goauto.com.au/amp/audi/a4/e-tron/audi-a4-e-tron-confirmed-first-details-emerge/2026-06-29/99667.html), med henvisning til egne kilder, at A4 e-tron blir den første Audien som utnytter hele SSP-pakken, inkludert en enhetlig batteriarkitektur og sonebasert elektronikk. Audi har ennå ikke offentliggjort batteristørrelse, rekkevidde, ladeeffekt eller motorytelser. En Avant er ønsket av Mohr, men er foreløpig ikke formelt bekreftet.
+
+Kilder: [GoAuto, 29. juni 2026](https://www.goauto.com.au/amp/audi/a4/e-tron/audi-a4-e-tron-confirmed-first-details-emerge/2026-06-29/99667.html) og [Autocar, 7. oktober 2025](https://www.autocar.co.uk/car-news/new-cars/new-audi-a4-bring-next-gen-tech-and-tt-inspired-look).
 
 {{<children description="true" />}}


### PR DESCRIPTION
Updates the Audi A4 e-tron pages in English, Norwegian, and German with the latest confirmed SSP and 2028 timing information. Also updates the English and Norwegian model overview cards and clearly separates confirmed details from sourced but unconfirmed technical expectations. Sources include GoAuto, Autocar, and electrive.